### PR TITLE
Handle non-JSON response from Salesforce should

### DIFF
--- a/src/react.force.common.js
+++ b/src/react.force.common.js
@@ -56,8 +56,12 @@ var exec = function(moduleIOSName, moduleAndroidName, moduleIOS, moduleAndroid, 
             function(result) {
                 console.log(func + " succeeded");
                 if (successCB) {
-                    var resultParsed = result ? JSON.parse(result) : result;
-                    successCB(resultParsed)
+                    try {                        
+                        var resultParsed = result ? JSON.parse(result) : result;
+                        successCB(resultParsed);
+                    } catch(e) {
+                        successCB(result);
+                    }
                 };
             },
             function(error) {


### PR DESCRIPTION
This is a simple fix for responses from Salesforce that are not properly formatted JSON.  An example could be an APEX error from a custom APEX rest api (depending on how that is written).  Although this `catch` shouldn't get exercised, this will prevent an app from cashing in case it does.