### PR TITLE
Binary download support for react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     }
   ],
   "dependencies": {
-    "react-native": "^0.50.4"
+      "react-native": "^0.50.4",
+      "base-64": "^0.1.0"
   },
   "peerDependencies": {
     "react-native": ">=0.50.4"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     }
   ],
   "dependencies": {
-      "react-native": "^0.50.4",
-      "base-64": "^0.1.0"
+      "react-native": "^0.50.4"
   },
   "peerDependencies": {
     "react-native": ">=0.50.4"

--- a/src/react.force.net.js
+++ b/src/react.force.net.js
@@ -50,10 +50,8 @@ export const sendRequest = (endPoint, path, successCB, errorCB, method, payload,
     method = method || "GET";
     payload = payload || {};
     headerParams = headerParams || {};
-    // File params expected to be of the form:
-    // {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}
-    fileParams = fileParams || {};
-    returnBinary = !!returnBinary;
+    fileParams = fileParams || {}; // File params expected to be of the form: {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}
+    returnBinary = !!returnBinary; // when true response returned as {encodedBody:"base64-encoded-response", contentType:"content-type"}
 
     const args = {endPoint, path, method, queryParams:payload, headerParams, fileParams, returnBinary};    
     forceExec("SFNetReactBridge", "SalesforceNetReactBridge", SFNetReactBridge, SalesforceNetReactBridge, successCB, errorCB, "sendRequest", args);
@@ -215,7 +213,7 @@ export const search = (sosl, callback, error) => sendRequest('/services/data', `
 /**
  * Convenience function to retrieve an attachment
  * @param id 
- * @param successHandler
- * @param errorHandler
+ * @param callback function to which response will be passed (attachment is returned as {encodedBody:"base64-encoded-response", contentType:"content-type"})
+ * @param [error=null] function called in case of error
  */
 export const getAttachment = (id, callback, error) => sendRequest('/services/data/', `/${apiVersion}/sobjects/Attachment/${id}/Body`, callback, error, 'GET', null, null, null, true /* return binary */);

--- a/src/react.force.net.js
+++ b/src/react.force.net.js
@@ -46,16 +46,16 @@ export const getApiVersion = () => apiVersion;
 /** 
  * Send arbitray force.com request
  */
-export const sendRequest = (endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams, returnResponseAsBlob) => {
+export const sendRequest = (endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams, returnBinary) => {
     method = method || "GET";
     payload = payload || {};
     headerParams = headerParams || {};
     // File params expected to be of the form:
     // {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}
     fileParams = fileParams || {};
-    returnResponseAsBlob = !!returnResponseAsBlob;
+    returnBinary = !!returnBinary;
 
-    const args = {endPoint, path, method, queryParams:payload, headerParams, fileParams, returnResponseAsBlob};    
+    const args = {endPoint, path, method, queryParams:payload, headerParams, fileParams, returnBinary};    
     forceExec("SFNetReactBridge", "SalesforceNetReactBridge", SFNetReactBridge, SalesforceNetReactBridge, successCB, errorCB, "sendRequest", args);
 };
 


### PR DESCRIPTION
New flag `returnBinary` (default false) in network bridge `sendRequest` method.
Added `getAttachment()` helper method.

Example
```javascript
        net.getAttachment("--valid-attachment-id--", (response) => that.setState({
            imageSrc: {uri: `data:${response.contentType};base64,${response.encodedBody}`}
        }));
```
Assuming the following is being rendered
```html
  <Image source={this.state.imageSrc} style={{width:100, height:100}}/>
```