### PR TITLE
Upsert with null external id

### DIFF
--- a/src/react.force.net.js
+++ b/src/react.force.net.js
@@ -154,7 +154,7 @@ export const retrieve = function(objtype, id, fieldlist, callback, error) {
  * @param callback function to which response will be passed
  * @param [error=null] function called in case of error
  */
-export const upsert = (objtype, externalIdField, externalId, fields, callback, error) => sendRequest('/services/data', `/${apiVersion}/sobjects/${objtype}/${externalIdField}/${externalId}`, callback, error, "PATCH", fields);
+export const upsert = (objtype, externalIdField, externalId, fields, callback, error) => sendRequest('/services/data', `/${apiVersion}/sobjects/${objtype}/${externalIdField}/${externalId?externalId:''}`, callback, error, externalId ? "PATCH" : "POST", fields);
 
 /*
  * Updates field values on a record of the given type.


### PR DESCRIPTION
Since v37, upsert with external id null is allowed - it does a create (but post must be used).
We made the change on the native side last year.