### PR TITLE
Test fails if a unhandled promise rejection is detected

### DIFF
--- a/src/react.force.util.js
+++ b/src/react.force.util.js
@@ -25,9 +25,22 @@
  */
 
 import React from 'react';
+const rejectionTracking = require('promise/setimmediate/rejection-tracking');
 const timer = require('react-native-timer');
 
+const enableErrorOnUnhandledPromiseRejection = () => {
+    rejectionTracking.enable({
+        allRejections: true,
+        onUnhandled: (id, error) => {
+            const strError =  JSON.stringify(error);
+            console.error("------> Unhandled promise rejection with error: " + strError);
+        },
+        onHandled: () => {},
+    });    
+};
+
 export const promiser = (func) => {
+    enableErrorOnUnhandledPromiseRejection();
     var retfn = function() {
         var args = Array.prototype.slice.call(arguments);
 


### PR DESCRIPTION
Our tests use a lot of promises.
When a promise is rejected (e.g. some assert fails within), the test would fail by timing out.
Now the unhandled promise rejection is detected and cause the test to fail right away and report a more accurate failure message.