### PR TITLE
Helper func to turn functions with callbacks into promise 

### DIFF
--- a/src/react.force.util.js
+++ b/src/react.force.util.js
@@ -70,6 +70,30 @@ export const promiser = (func) => {
     return retfn;
 };
 
+export const promiserNoRejection = (func) => {
+    enableErrorOnUnhandledPromiseRejection();
+	var retfn = function() {
+		var args = Array.prototype.slice.call(arguments)
+
+		return new Promise(function(resolve, reject) {
+			// then() will be called whether it succeeded or failed
+			const callback = () => {
+				try {
+					resolve.apply(null, arguments)
+				}
+				catch (err) {
+                    console.error("------> Error when calling callback for " + func.name);
+					console.error(err.stack);
+				}
+			}
+			args.push(callback) 
+			args.push(callback)
+			console.debug("-----> Calling " + func.name)
+			func.apply(null, args)
+		});
+	};
+	return retfn;
+};
 
 export const timeoutPromiser = (millis) => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
where the then() is invoked both in case of success and error

For instance, you might want to do a sync and then a refresh of a list.
You want the refresh to happen even if the network is down (which will cause the sync to fail).

NB: That helper function was developed and used in the graph ql experiment.