### PR TITLE
Move to RN 0.56.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     }
   ],
   "dependencies": {
-      "react-native": "0.55.4",
+      "react-native": "0.57.1",
       "react-native-timer": "^1.3.1"
+  },
+  "peerDependencies": {
+    "react": ">=16.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,5 @@
   "dependencies": {
       "react-native": "0.56.1",
       "react-native-timer": "^1.3.1"
-  },
-  "peerDependencies": {
-    "react": ">=16.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   ],
   "dependencies": {
-      "react-native": "0.57.1",
+      "react-native": "0.56.1",
       "react-native-timer": "^1.3.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Moving to RN 0.56.1, first tried 0.57.1, but ran into an issue (see https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/commit/1add4778589616feafb9500b91fd5ed005510a0e)