### PR TITLE
switch to use peer dependencies on react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
       "email": "bhariharan@salesforce.com"
     }
   ],
+  "peerDependencies": {
+   "react-native": "0.56.1"
+  },
   "dependencies": {
-    "react-native": "0.56.1",
     "react-native-timer": "^1.3.1"
   },
   "files": [


### PR DESCRIPTION
React native should be set as peerDependencies which react-native-force relies it's consumer to setup the right dependencies for. Using dependencies on react-native will cause duplicate symbol on react if consumed directly by an existing app without using the template

@bhariharan @wmathurin 