### PR TITLE
Providing a way to set log level for messages coming from SDK

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,5 +31,6 @@ module.exports = {
     mobilesync:require('./src/react.force.mobilesync'),
     forceClient:require('./src/react.force.net'),
     forceUtil:require('./src/react.force.util'),
+    forceLog:require('./src/react.force.log'),
     forceTest:require('./src/react.force.test')
 };

--- a/src/react.force.common.js
+++ b/src/react.force.common.js
@@ -24,32 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-/**
- * logging support
- */
-var logLevel = "info";
-
-export const getLogLevel = () => {
-    return logLevel;
-};
-
-export const sdkConsole = { };
-
-export const setLogLevel = (level) => {
-    logLevel = level;
-    var methods = ["debug", "info", "warn", "error"];
-    var levelAsInt = methods.indexOf(level.toLowerCase());
-    var noop = () => {};
-
-    sdkConsole.debug = levelAsInt <= 0 ? console.debug.bind(console) : noop;
-    sdkConsole.info = levelAsInt <= 1 ? console.info.bind(console) : noop;
-    sdkConsole.warn = levelAsInt <= 2 ? console.log.bind(console) : noop; // we don't want the yellow box
-    sdkConsole.error = levelAsInt <= 3 ? console.error.bind(console) : noop; // we don't want the red box
-    sdkConsole.log = console.log.bind(console);
-};
-
-setLogLevel("info");
+import {sdkConsole} from './react.force.log';
 
 /**
  * exec

--- a/src/react.force.common.js
+++ b/src/react.force.common.js
@@ -24,22 +24,49 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+/**
+ * logging support
+ */
+var logLevel = "info";
+
+export const getLogLevel = () => {
+    return logLevel;
+};
+
+export const sdkConsole = { };
+
+export const setLogLevel = (level) => {
+    logLevel = level;
+    var methods = ["debug", "info", "warn", "error"];
+    var levelAsInt = methods.indexOf(level.toLowerCase());
+    var noop = () => {};
+
+    sdkConsole.debug = levelAsInt <= 0 ? console.debug.bind(console) : noop;
+    sdkConsole.info = levelAsInt <= 1 ? console.info.bind(console) : noop;
+    sdkConsole.warn = levelAsInt <= 2 ? console.log.bind(console) : noop; // we don't want the yellow box
+    sdkConsole.error = levelAsInt <= 3 ? console.error.bind(console) : noop; // we don't want the red box
+    sdkConsole.log = console.log.bind(console);
+};
+
+setLogLevel("info");
+
 /**
  * exec
  */
 export const exec = (moduleIOSName, moduleAndroidName, moduleIOS, moduleAndroid, successCB, errorCB, methodName, args) => {
     if (moduleIOS) {
         const func = `${moduleIOSName}.${methodName}`;
-        console.log(`${func} called: ${JSON.stringify(args)}`);
+        sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
         moduleIOS[methodName](
             args,
             (error, result) => {
                 if (error) {
-                    console.log(`${func} failed: ${JSON.stringify(error)}`);
+                    sdkConsole.error(`${func} failed: ${JSON.stringify(error)}`);
                     if (errorCB) errorCB(error);
                 }
                 else {
-                    console.log(`${func} succeeded`);
+                    sdkConsole.debug(`${func} succeeded`);
                     if (successCB) successCB(result);
                 }
             });
@@ -47,17 +74,17 @@ export const exec = (moduleIOSName, moduleAndroidName, moduleIOS, moduleAndroid,
     // android
     else if (moduleAndroid) {
         const func = `${moduleAndroidName}.${methodName}`;
-        console.log(`${func} called: ${JSON.stringify(args)}`);
+        sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
         moduleAndroid[methodName](
             args,
             result => {
-                console.log(`${func} succeeded`);
+                sdkConsole.debug(`${func} succeeded`);
                 if (successCB) {
                     successCB(safeJSONparse(result));
                 };
             },
             error => {
-                console.log(`${func} failed`);
+                sdkConsole.error(`${func} failed: ${JSON.stringify(error)}`);
                 if (errorCB) errorCB(safeJSONparse(error));
             }
         );

--- a/src/react.force.log.js
+++ b/src/react.force.log.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * logging support
+ */
+var logLevel = "info";
+
+export const getLogLevel = () => {
+    return logLevel;
+};
+
+export const sdkConsole = { };
+
+export const setLogLevel = (level) => {
+    logLevel = level;
+    var methods = ["debug", "info", "warn", "error"];
+    var levelAsInt = methods.indexOf(level.toLowerCase());
+    var noop = () => {};
+
+    sdkConsole.debug = levelAsInt <= 0 ? console.debug.bind(console) : noop;
+    sdkConsole.info = levelAsInt <= 1 ? console.info.bind(console) : noop;
+    sdkConsole.warn = levelAsInt <= 2 ? console.log.bind(console) : noop; // we don't want the yellow box
+    sdkConsole.error = levelAsInt <= 3 ? console.error.bind(console) : noop; // we don't want the red box
+    sdkConsole.log = console.log.bind(console);
+};
+
+setLogLevel("info");
+

--- a/src/react.force.log.js
+++ b/src/react.force.log.js
@@ -45,7 +45,7 @@ export const setLogLevel = (level) => {
     sdkConsole.debug = levelAsInt <= 0 ? console.debug.bind(console) : noop;
     sdkConsole.info = levelAsInt <= 1 ? console.info.bind(console) : noop;
     sdkConsole.warn = levelAsInt <= 2 ? console.log.bind(console) : noop; // we don't want the yellow box
-    sdkConsole.error = levelAsInt <= 3 ? console.error.bind(console) : noop; // we don't want the red box
+    sdkConsole.error = levelAsInt <= 3 ? console.log.bind(console) : noop; // we don't want the red box
     sdkConsole.log = console.log.bind(console);
 };
 

--- a/src/react.force.util.js
+++ b/src/react.force.util.js
@@ -34,7 +34,7 @@ const enableErrorOnUnhandledPromiseRejection = () => {
         allRejections: true,
         onUnhandled: (id, error) => {
             const strError =  JSON.stringify(error);
-            sdkConsole.error("------> Unhandled promise rejection with error: " + strError);
+            sdkConsole.error("Unhandled promise rejection with error: " + strError);
         },
         onHandled: () => {},
     });    
@@ -51,7 +51,7 @@ export const promiser = (func) => {
                     resolve.apply(null, arguments);
                 }
                 catch (err) {
-                    sdkConsole.error("------> Error when calling successCB for " + func.name);
+                    sdkConsole.error("Error when calling successCB for " + func.name);
                     sdkConsole.error(err.stack);
                 }
             });
@@ -60,11 +60,11 @@ export const promiser = (func) => {
                     reject.apply(null, arguments);
                 }
                 catch (err) {
-                    sdkConsole.error("------> Error when calling errorCB for " + func.name);
+                    sdkConsole.error("Error when calling errorCB for " + func.name);
                     sdkConsole.error(err.stack);
                 }
             });
-            sdkConsole.debug("-----> Calling " + func.name);
+            sdkConsole.debug("Calling " + func.name);
             func.apply(null, args);
         });
     };
@@ -83,13 +83,13 @@ export const promiserNoRejection = (func) => {
 					resolve.apply(null, arguments)
 				}
 				catch (err) {
-                    sdkConsole.error("------> Error when calling callback for " + func.name);
+                    sdkConsole.error("Error when calling callback for " + func.name);
 					sdkConsole.error(err.stack);
 				}
 			}
 			args.push(callback) 
 			args.push(callback)
-			sdkConsole.debug("-----> Calling " + func.name)
+			sdkConsole.debug("Calling " + func.name)
 			func.apply(null, args)
 		});
 	};

--- a/src/react.force.util.js
+++ b/src/react.force.util.js
@@ -25,7 +25,7 @@
  */
 
 import React from 'react';
-import {sdkConsole} from './react.force.common';
+import {sdkConsole} from './react.force.log';
 const rejectionTracking = require('promise/setimmediate/rejection-tracking');
 const timer = require('react-native-timer');
 

--- a/src/react.force.util.js
+++ b/src/react.force.util.js
@@ -25,6 +25,7 @@
  */
 
 import React from 'react';
+import {sdkConsole} from './react.force.common';
 const rejectionTracking = require('promise/setimmediate/rejection-tracking');
 const timer = require('react-native-timer');
 
@@ -33,7 +34,7 @@ const enableErrorOnUnhandledPromiseRejection = () => {
         allRejections: true,
         onUnhandled: (id, error) => {
             const strError =  JSON.stringify(error);
-            console.error("------> Unhandled promise rejection with error: " + strError);
+            sdkConsole.error("------> Unhandled promise rejection with error: " + strError);
         },
         onHandled: () => {},
     });    
@@ -50,8 +51,8 @@ export const promiser = (func) => {
                     resolve.apply(null, arguments);
                 }
                 catch (err) {
-                    console.error("------> Error when calling successCB for " + func.name);
-                    console.error(err.stack);
+                    sdkConsole.error("------> Error when calling successCB for " + func.name);
+                    sdkConsole.error(err.stack);
                 }
             });
             args.push(function() {
@@ -59,11 +60,11 @@ export const promiser = (func) => {
                     reject.apply(null, arguments);
                 }
                 catch (err) {
-                    console.error("------> Error when calling errorCB for " + func.name);
-                    console.error(err.stack);
+                    sdkConsole.error("------> Error when calling errorCB for " + func.name);
+                    sdkConsole.error(err.stack);
                 }
             });
-            console.debug("-----> Calling " + func.name);
+            sdkConsole.debug("-----> Calling " + func.name);
             func.apply(null, args);
         });
     };
@@ -82,13 +83,13 @@ export const promiserNoRejection = (func) => {
 					resolve.apply(null, arguments)
 				}
 				catch (err) {
-                    console.error("------> Error when calling callback for " + func.name);
-					console.error(err.stack);
+                    sdkConsole.error("------> Error when calling callback for " + func.name);
+					sdkConsole.error(err.stack);
 				}
 			}
 			args.push(callback) 
 			args.push(callback)
-			console.debug("-----> Calling " + func.name)
+			sdkConsole.debug("-----> Calling " + func.name)
 			func.apply(null, args)
 		});
 	};


### PR DESCRIPTION
Default log level is info so by default it will be a lot less verbose than before.
To change the log level simply do:

```javascript
import { forceLog } from 'react-native-force';
forceLog.setLogLevel("debug"); // other valid values: info, warn, error
```
