### PR TITLE
Save binary response to a file

### DIFF
--- a/src/react.force.net.js
+++ b/src/react.force.net.js
@@ -46,14 +46,14 @@ export const getApiVersion = () => apiVersion;
 /**
  * Send arbitray force.com request
  */
-export const sendRequest = (endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams, returnBinary, doesNotRequireAuthentication) => {
+export const sendRequest = (endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams, returnBinary, doesNotRequireAuthentication,fileDownloadParams) => {
     method = method || "GET";
     payload = payload || {};
     headerParams = headerParams || {};
     fileParams = fileParams || {}; // File params expected to be of the form: {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}
     returnBinary = !!returnBinary;
     doesNotRequireAuthentication = !!doesNotRequireAuthentication;
-    const args = {endPoint, path, method, queryParams:payload, headerParams, fileParams, returnBinary, doesNotRequireAuthentication};
+    const args = {endPoint, path, method, queryParams:payload, headerParams, fileParams, returnBinary, doesNotRequireAuthentication, fileDownloadParams};
     forceExec("SFNetReactBridge", "SalesforceNetReactBridge", SFNetReactBridge, SalesforceNetReactBridge, successCB, errorCB, "sendRequest", args);
 };
 


### PR DESCRIPTION
Currently, binary responses are converted to base64 strings and passed to the JS. 
This diff includes changes that will enable saving response body to a file and return the path to the file instead of massive base64 strings.