### PR TITLE
Callback in logout()

### DIFF
--- a/ios/SalesforceReact/SFOauthReactBridge.m
+++ b/ios/SalesforceReact/SFOauthReactBridge.m
@@ -53,6 +53,16 @@ RCT_EXPORT_METHOD(getAuthCredentials:(NSDictionary *)args callback:(RCTResponseS
 RCT_EXPORT_METHOD(logoutCurrentUser:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
     [SFSDKReactLogger d:[self class] format:@"logoutCurrentUser: arguments: %@", args];
+
+    id observer;
+    observer = [[NSNotificationCenter defaultCenter]
+                   addObserverForName:kSFNotificationUserDidLogout
+                   object:nil
+                   queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        callback(@[[NSNull null], @"OK"]);
+        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    }];
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [[SFUserAccountManager sharedInstance] logout];
     });

--- a/ios/SalesforceReact/SFOauthReactBridge.m
+++ b/ios/SalesforceReact/SFOauthReactBridge.m
@@ -54,14 +54,15 @@ RCT_EXPORT_METHOD(logoutCurrentUser:(NSDictionary *)args callback:(RCTResponseSe
 {
     [SFSDKReactLogger d:[self class] format:@"logoutCurrentUser: arguments: %@", args];
 
-    id observer;
-    observer = [[NSNotificationCenter defaultCenter]
+    __block id observerRef;
+    id observer = [[NSNotificationCenter defaultCenter]
                    addObserverForName:kSFNotificationUserDidLogout
                    object:nil
                    queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
         callback(@[[NSNull null], @"OK"]);
-        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+        [[NSNotificationCenter defaultCenter] removeObserver:observerRef];
     }];
+    observerRef = observer;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [[SFUserAccountManager sharedInstance] logout];

--- a/src/react.force.oauth.js
+++ b/src/react.force.oauth.js
@@ -33,12 +33,6 @@ const exec = (successCB, errorCB, methodName, args) => {
 };
 
 /**
- * Whether or not logout has already been initiated.  Can only be initiated once
- * per page load.
- */
-let logoutInitiated = false;
-
-/**
  * Initiates the authentication process, with the given app configuration.
  *   success         - The success callback function to use.
  *   fail            - The failure/error callback function to use.
@@ -80,20 +74,9 @@ export const getAuthCredentials = (success, fail) => {
 
 /**
  * Logout the current authenticated user. This removes any current valid session token
- * as well as any OAuth refresh token.  The user is forced to login again.
- * This method does not call back with a success or failure callback, as
- * (1) this method must not fail and (2) in the success case, the current user
- * will be logged out and asked to re-authenticate.  Note also that this method can only
- * be called once per page load.  Initiating logout will ultimately redirect away from
- * the given page (effectively resetting the logout flag), and calling this method again
- * while it's currently processing will result in app state issues.
+ * as well as any OAuth refresh token.  
  */
-export const logout = () => {
-    // only set callback for android, since iOS will not invoke callback.
-    const logoutCb = SalesforceOauthReactBridge ? () => { logoutInitiated = false; } : null;
-    if (!logoutInitiated) {
-        logoutInitiated = true;
-        exec(logoutCb, null, "logoutCurrentUser", {});
-    }
+export const logout = (success, fail) => {
+    exec(sucess, fail, "logoutCurrentUser", {});
 };
 


### PR DESCRIPTION
This will allow application that use defer login to know when the logout has completed.
The js and the ios code needed to be changed but the android code was already expecting a callback.
There is a new basic template that does deferred login and demonstrates using the logout callback. See https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/278