### PR TITLE
Podspec update to fix Xcode 12 build errors

### DIFF
--- a/SalesforceReact.podspec
+++ b/SalesforceReact.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.default_subspec  = 'SalesforceReact'
   s.subspec 'SalesforceReact' do |salesforcereact|
-      salesforcereact.dependency 'React'
+      salesforcereact.dependency 'React-Core'
       salesforcereact.dependency 'MobileSync', "~>#{s.version}"
       salesforcereact.source_files = 'ios/SalesforceReact/**/*.{h,m}'
       salesforcereact.public_header_files = 'ios/SalesforceReact/SFNetReactBridge.h', 'ios/SalesforceReact/SFOauthReactBridge.h', 'ios/SalesforceReact/SFSDKReactLogger.h', 'ios/SalesforceReact/SFSmartStoreReactBridge.h', 'ios/SalesforceReact/SFMobileSyncReactBridge.h', 'libs/SalesforceReact/SalesforceReact/SalesforceReact.h', 'ios/SalesforceReact/SalesforceReactSDKManager.h'


### PR DESCRIPTION
Xcode 12 requires the React dependency to be ported from `React` to `React-Core`.

[See here](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116) for the callout, and [see here](https://github.com/react-native-webview/react-native-webview/pull/1643/files) for the react-native-webview PR.

I also believe there is work to do regarding the Salesforce SDK references. This PR does not fix that.

For those who are running into this issue, put this at the bottom of your `ios/Podfile` to patch fix it in the meantime.

```rb
post_install do |installer_representation|
    installer_representation.pods_project.targets.each do |target|
        #Workaround for Xcode 12 and Auto-Linking
        installer_representation.pods_project.targets.each do |target|
            if ['react-native-safe-area-context', 'RNGestureHandler', 'SalesforceReact'].include?(target.name) #list all affected target in the array
                target.build_phases.each do |build_phases|
                    if build_phases.display_name == 'Frameworks'
                        file_ref = installer_representation.pods_project.new(Xcodeproj::Project::Object::PBXFileReference)
                        file_ref.path = 'React.framework'
                        file_ref.source_tree = 'BUILT_PRODUCTS_DIR'
                        build_phases.add_file_reference(file_ref)
                    end
                end
            end
            if ['SalesforceReact'].include?(target.name) #list all affected target in the array
                target.build_phases.each do |build_phases|
                    if build_phases.display_name == 'Frameworks'
                        ['SalesforceSDKCommon', 'SalesforceAnalytics', 'SalesforceSDKCore', 'SmartStore', 'MobileSync'].each do | sdk |
                            file_ref = installer_representation.pods_project.new(Xcodeproj::Project::Object::PBXFileReference)
                            file_ref.path = "#{sdk}.framework"
                            file_ref.source_tree = 'BUILT_PRODUCTS_DIR'
                            build_phases.add_file_reference(file_ref)
                        end
                    end
                end
            end
        end
    end
end
```