### PR TITLE
Cleaning up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build tsconfig.json",
+    "build": "tsc --build",
     "postinstall": "yarn build",
     "prepublish": "npm run build"
   },
@@ -56,7 +56,6 @@
     "react-native-timer": "^1.3.6"
   },
   "files": [
-    "dist/*",
     "tsconfig.json",
     "src/**/*",
     "ios/SalesforceReact/**/*",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build tsconfig.json",
     "postinstall": "yarn build",
     "prepublish": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist && mkdir dist && tsc",
+    "build": "tsc",
     "postinstall": "yarn build",
     "prepublish": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-native-timer": "^1.3.6"
   },
   "files": [
+    "dist/*",
     "tsconfig.json",
     "src/**/*",
     "ios/SalesforceReact/**/*",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-native-timer": "^1.3.6"
   },
   "files": [
-    "dist/index.js",
+    "tsconfig.json",
     "src/**/*",
     "ios/SalesforceReact/**/*",
     "SalesforceReact.podspec"


### PR DESCRIPTION
We don't need to `rm -rf  & mkdir dist` in build step (that would not work on windows)
We don't need dist in files (dist in generated after install)