### PR TITLE
Moving to RN 66

### DIFF
--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -11,12 +11,13 @@
     "dependencies": {
         "create-react-class": "^15.7.0",
         "react": "17.0.2",
-        "react-native": "0.65.1",
+        "react-native": "0.66.0",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
     },
     "devDependencies": {
         "@babel/core": "^7.12.9",
         "@babel/runtime": "^7.12.5",
+        "@babel/preset-env": "^7.1.6",
         "@react-native-community/cli": "^6.0.0",
         "@react-native-community/eslint-config": "^2.0.0",
         "@types/jest": "^26.0.18",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react-native": "0.65.1"
+    "react-native": "0.66.0"
   },
   "dependencies": {
     "react-native-timer": "^1.3.6"
@@ -63,7 +63,7 @@
   ],
   "devDependencies": {
     "@types/chai": "^4.2.14",
-    "@types/react-native": "^0.64.13",
+    "@types/react-native": "^0.65.4",
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
     "eslint": "^7.15.0",


### PR DESCRIPTION
NB: CI will fail before the PR is merged because it will try to build / run the tests with https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev which doesn't point to 0.66.0 (until we merge).