### PR TITLE
Use regular react class components rather than create-react-class

### DIFF
--- a/src/react.force.test.tsx
+++ b/src/react.force.test.tsx
@@ -27,22 +27,22 @@
 import * as React from "react";
 import { AppRegistry, NativeModules, View } from "react-native";
 const { SalesforceTestBridge, TestModule } = NativeModules;
-const createReactClass = require("create-react-class");
 
-const componentForTest = (test: any) => {
-  return createReactClass({
+class ComponentForTest extends React.Component<{ test: () => void }> {
     componentDidMount() {
-      test(); // NB: test must call testDone() when it completes
-    },
-
+        this.props.test();
+    }
     render() {
-      return <View />;
-    },
-  });
+        return (<View/>);
+    }
+}
+
+const testComponentProvider = (test: any) => {
+  return () => <ComponentForTest test={test} />;
 };
 
 export const registerTest = (test: any) => {
-  AppRegistry.registerComponent(test.name.substring("test".length), () => componentForTest(test));
+  AppRegistry.registerComponent(test.name.substring("test".length), () => testComponentProvider(test));
 };
 
 export const testDone = () => {


### PR DESCRIPTION
Use regular react class component instead of `create-react-class`, since the library is already using es6 and above anyway.
`create-react-class` brings in outdated libraries which have appeared in cv databases. 