### PR TITLE
tsc build was failing on clean clone

### DIFF
--- a/dist/react.force.net.d.ts
+++ b/dist/react.force.net.d.ts
@@ -1,7 +1,8 @@
 import { ExecErrorCallback, ExecSuccessCallback } from "./react.force.common";
+import { HttpMethod } from "./typings";
 export declare const setApiVersion: (version: string) => void;
 export declare const getApiVersion: () => string;
-export declare const sendRequest: <T>(endPoint: string, path: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback, method?: "POST" | "GET" | "PUT" | "PATCH" | "DELETE" | undefined, payload?: Record<string, unknown> | null | undefined, headerParams?: Record<string, unknown> | null | undefined, fileParams?: unknown, returnBinary?: boolean | undefined, doesNotRequireAuthentication?: boolean | undefined) => void;
+export declare const sendRequest: <T>(endPoint: string, path: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback, method?: HttpMethod | undefined, payload?: Record<string, unknown> | null | undefined, headerParams?: Record<string, unknown> | null | undefined, fileParams?: unknown, returnBinary?: boolean | undefined, doesNotRequireAuthentication?: boolean | undefined) => void;
 export declare const versions: <T>(successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
 export declare const resources: <T>(successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
 export declare const describeGlobal: <T>(successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;

--- a/setversion.sh
+++ b/setversion.sh
@@ -58,5 +58,6 @@ echo "*** Updating podspecs ***"
 update_podspec "./SalesforceReact.podspec" "${OPT_VERSION}"
 
 echo "*** Updating dist ***"
+npm install
 npm run build
 


### PR DESCRIPTION
`tsc --build` is called when doing `setversion.sh` during the release.
If `npm i` was never run, it fails.
I changed `setversion.sh` to do a `npm i`, and I also re-ran `setversion.sh -v 9.2.0 -d no`