### PR TITLE
Bump React Native to 0.67.1.

### DIFF
--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "create-react-class": "^15.7.0",
         "react": "17.0.2",
-        "react-native": "0.67.0",
+        "react-native": "0.67.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react-native": "0.67.0"
+    "react-native": "^0.67.1"
   },
   "dependencies": {
     "react-native-timer": "^1.3.6"


### PR DESCRIPTION
This is fixes a crash for Android release builds.