### PR TITLE
Update CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,49 +3,42 @@
 #  NOTE: When updaing Xcode check the manifest for compatible chruby versions.
 anchors:
   - &latest-xcode "13.4.1"
-  - &beta-xcode   "14.0.0"
   - &latest-ios   "15.5"
   - &min-ios      "14.5"
-  - &beta-ios     "16.0"
   - &chruby       "3.1.2"
+  - &invalid      ""
 
 executors:
   mac:
-    working_directory: ~/SalesforceMobileSDK-ReactNative
     macos:
       xcode: *latest-xcode
-    shell: /bin/bash --login -eo pipefail
-    environment:
-      BASH_ENV: ~/.bashrc
-      FASTLANE_SKIP_UPDATE_CHECK: "true"
-      CHRUBY_VER: *chruby
-  mac-beta:
-    working_directory: ~/SalesforceMobileSDK-ReactNative
-    macos:
-      xcode: *beta-xcode
-    shell: /bin/bash --login -eo pipefail
-    environment:
-      BASH_ENV: ~/.bashrc
-      FASTLANE_SKIP_UPDATE_CHECK: "true"
-      CHRUBY_VER: *chruby
 
 version: 2.1
 jobs:
   test-ios:
     parameters:
+      xcode:
+        type: string
+        default: *latest-xcode
       ios:
         type: string
         default: *latest-ios
+      chruby:
+        type: string
+        default: *chruby
       device:
         type: string
         default: "iPhone 12"
-      env: 
-        type: executor
-        default: "mac"
-    executor: << parameters.env >> 
+    macos:
+      xcode: << parameters.xcode >>
+    working_directory: ~/SalesforceMobileSDK-ReactNative
+    shell: /bin/bash --login -eo pipefail
     environment:
       DEVICE: << parameters.device >>
       IOS_VERSION: << parameters.ios >>
+      BASH_ENV: ~/.bashrc
+      FASTLANE_SKIP_UPDATE_CHECK: "true"
+      CHRUBY_VER: << parameters.chruby >>
     steps:
       - checkout
       - run:
@@ -81,9 +74,15 @@ jobs:
 
 #  Potential parameters that can come from the project GUI Triggers
 parameters:
-  beta:
-    type: boolean
-    default: false
+  xcode:
+    type: string
+    default: *invalid
+  ios:
+    type: string
+    default: *invalid
+  chruby:
+    type: string
+    default: *chruby
 
 workflows:
   version: 2
@@ -97,8 +96,10 @@ workflows:
   # Build everything at 10 PM PST Sunday
   run-tests:
     when:
-      not:  
-        equal: [ "webhook", << pipeline.trigger_source >> ]
+      and:
+        - not: << pipeline.parameters.xcode >>
+        - not:  
+            equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - test-ios:
           name: test ReactNative iOS << matrix.ios >>
@@ -110,14 +111,16 @@ workflows:
   run-tests-beta:
     when:
       and:
-        - << pipeline.parameters.beta >>
+        - << pipeline.parameters.xcode >>
+        - << pipeline.parameters.ios >>
         - not:  
             equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - test-ios:
-          name: test ReactNative iOS << matrix.ios >>
+          name: test ReactNative iOS << pipeline.parameters.ios >>
           matrix:
             parameters:
-              ios: [*beta-ios]
+              xcode: [<< pipeline.parameters.xcode >>]
+              ios: [<< pipeline.parameters.ios >>]
+              chruby: [<< pipeline.parameters.chruby >>]
               device: ["iPhone 13"]
-              env: ["mac-beta"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ executors:
       FASTLANE_SKIP_UPDATE_CHECK: "true"
       CHRUBY_VER: *chruby
   mac-beta:
-    working_directory: ~/SalesforceMobileSDK-iOS
+    working_directory: ~/SalesforceMobileSDK-ReactNative
     macos:
       xcode: *beta-xcode
     shell: /bin/bash --login -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,13 @@
+#  Xcode version announcments can be found here: https://discuss.circleci.com/c/announcements/
+#  Each post contains a full image manifest, including iOS runtimes, devices, CocoaPods version, etc.
+#  NOTE: When updaing Xcode check the manifest for compatible chruby versions.
 anchors:
-  - &latest-xcode "13.2.1"
-  - &latest-ios   "15.2"
+  - &latest-xcode "13.4.1"
+  - &beta-xcode   "14.0.0"
+  - &latest-ios   "15.5"
   - &min-ios      "14.5"
+  - &beta-ios     "16.0"
+  - &chruby       "3.1.2"
 
 executors:
   mac:
@@ -10,22 +16,29 @@ executors:
       xcode: *latest-xcode
     shell: /bin/bash --login -eo pipefail
     environment:
-      BASH_ENV: ~/.bashr
+      BASH_ENV: ~/.bashrc
       FASTLANE_SKIP_UPDATE_CHECK: "true"
+      CHRUBY_VER: *chruby
+  mac-beta:
+    working_directory: ~/SalesforceMobileSDK-iOS
+    macos:
+      xcode: *beta-xcode
+    shell: /bin/bash --login -eo pipefail
+    environment:
+      BASH_ENV: ~/.bashrc
+      FASTLANE_SKIP_UPDATE_CHECK: "true"
+      CHRUBY_VER: *chruby
 
 version: 2.1
 jobs:
   test-ios:
     parameters:
-      device:
-        type: string
-        default: "iPhone 12"
       ios:
         type: string
         default: *latest-ios
-      nightly-test:
-        type: boolean
-        default: false
+      device:
+        type: string
+        default: "iPhone 12"
       env: 
         type: executor
         default: "mac"
@@ -33,7 +46,6 @@ jobs:
     environment:
       DEVICE: << parameters.device >>
       IOS_VERSION: << parameters.ios >>
-      NIGHTLY_TEST: << parameters.nightly-test >>
     steps:
       - checkout
       - run:
@@ -67,28 +79,45 @@ jobs:
           path: /Users/distiller/SalesforceMobileSDK-ReactNative/iosTests/ios/clangReport/
           destination: Static-Analysis
 
+#  Potential parameters that can come from the project GUI Triggers
+parameters:
+  beta:
+    type: boolean
+    default: false
+
 workflows:
   version: 2
 
   pr-run-tests:
+    when: 
+      equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - test-ios
 
-  # Cron are on a timezone 8 hours ahead of PST
-  # Build everything at ~11:30pm Sunday/Wednesday Nights
+  # Build everything at 10 PM PST Sunday
   run-tests:
-    triggers:
-      - schedule:
-          cron: "30 7 * * 1,4"
-          filters:
-            branches:
-              only:
-                - dev
+    when:
+      not:  
+        equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - test-ios:
           name: test ReactNative iOS << matrix.ios >>
           matrix:
             parameters:
-              nightly-test: [true]
               ios: [*min-ios, *latest-ios]
-              device: ["iPhone 12"]
+
+  # Build everything at 11 PM PST Sunday
+  run-tests-beta:
+    when:
+      and:
+        - << pipeline.parameters.beta >>
+        - not:  
+            equal: [ "webhook", << pipeline.trigger_source >> ]
+    jobs:
+      - test-ios:
+          name: test ReactNative iOS << matrix.ios >>
+          matrix:
+            parameters:
+              ios: [*beta-ios]
+              device: ["iPhone 13"]
+              env: ["mac-beta"]

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -1,5 +1,5 @@
-$device = ENV.has_key?('DEVICE') ? ENV['DEVICE'] : 'iPhone 11'
-$ios = ENV.has_key?('IOS_VERSION') ? ENV['IOS_VERSION'] : '14.1'
+$device = ENV.has_key?('DEVICE') ? ENV['DEVICE'] : 'iPhone 12'
+$ios = ENV.has_key?('IOS_VERSION') ? ENV['IOS_VERSION'] : '15.5'
 
 lane :build do
     analyze_scheme("SalesforceReactTestApp")


### PR DESCRIPTION
- Add Xcode 14/iOS 16 beta runs (dynamically from GUI triggers).
- Convert triggers from deprecated Scheduled Workflows to Scheduled Pipelines, specified in "Triggers" tab of project settings on CircleCi website. This change makes triggering tests manually though the GUI possible (and easy) against any branch.