### PR TITLE
React Native New Architecture (TurboModules) - iOS

### DIFF
--- a/SalesforceReact.podspec
+++ b/SalesforceReact.podspec
@@ -23,6 +23,11 @@ Pod::Spec.new do |s|
       salesforcereact.prefix_header_contents = '#import "SFSDKReactLogger.h"'
       salesforcereact.requires_arc = true
 
+      # Set C++20 standard required for new architecture TurboModule support.
+      salesforcereact.pod_target_xcconfig = {
+        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20'
+      }
+
       # Pulls in dependencies needed for the new architecture (Codegen-generated
       # spec headers, ReactCommon, JSI, etc.). Defined by React Native's
       # react_native_pods.rb. This is a no-op when new arch is disabled at the

--- a/SalesforceReact.podspec
+++ b/SalesforceReact.podspec
@@ -18,9 +18,17 @@ Pod::Spec.new do |s|
       salesforcereact.dependency 'SalesforceSDKCore', "~>#{s.version}"
       salesforcereact.dependency 'SmartStore', "~>#{s.version}"
       salesforcereact.dependency 'MobileSync', "~>#{s.version}"
-      salesforcereact.source_files = 'ios/SalesforceReact/**/*.{h,m}'
+      salesforcereact.source_files = 'ios/SalesforceReact/**/*.{h,m,mm}'
       salesforcereact.public_header_files = 'ios/SalesforceReact/SFNetReactBridge.h', 'ios/SalesforceReact/SFOauthReactBridge.h', 'ios/SalesforceReact/SFSDKReactLogger.h', 'ios/SalesforceReact/SFSmartStoreReactBridge.h', 'ios/SalesforceReact/SFMobileSyncReactBridge.h', 'libs/SalesforceReact/SalesforceReact/SalesforceReact.h', 'ios/SalesforceReact/SalesforceReactSDKManager.h'
       salesforcereact.prefix_header_contents = '#import "SFSDKReactLogger.h"'
       salesforcereact.requires_arc = true
+
+      # Pulls in dependencies needed for the new architecture (Codegen-generated
+      # spec headers, ReactCommon, JSI, etc.). Defined by React Native's
+      # react_native_pods.rb. This is a no-op when new arch is disabled at the
+      # consuming app level.
+      if defined?(install_modules_dependencies)
+          install_modules_dependencies(salesforcereact)
+      end
   end
 end

--- a/ios/SalesforceReact/SFMobileSyncReactBridge.h
+++ b/ios/SalesforceReact/SFMobileSyncReactBridge.h
@@ -25,9 +25,17 @@
 
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNSalesforceReactSpec/RNSalesforceReactSpec.h>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface SFMobileSyncReactBridge : NSObject <RCTBridgeModule, NativeSFMobileSyncReactBridgeSpec>
+#else
 @interface SFMobileSyncReactBridge : NSObject <RCTBridgeModule>
+#endif
 
 @end
 

--- a/ios/SalesforceReact/SFMobileSyncReactBridge.mm
+++ b/ios/SalesforceReact/SFMobileSyncReactBridge.mm
@@ -97,7 +97,7 @@ RCT_EXPORT_METHOD(syncDown:(NSDictionary *)args callback:(RCTResponseSenderBlock
     NSString *soupName = [args sfsdk_nonNullObjectForKey:kSyncSoupNameArg];
     SFSyncOptions *options = [SFSyncOptions newFromDict:[args sfsdk_nonNullObjectForKey:kSyncOptionsArg]];
     SFSyncDownTarget *target = [SFSyncDownTarget newFromDict:[args sfsdk_nonNullObjectForKey:kSyncTargetArg]];
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     NSError* error = nil;
     SFSyncState* sync = [[self getSyncManagerInst:args] syncDownWithTarget:target options:options soupName:soupName syncName:syncName updateBlock:^(SFSyncState* sync) {
         [weakSelf handleSyncUpdate:sync withArgs:args callback:callback];
@@ -118,14 +118,14 @@ RCT_EXPORT_METHOD(reSync:(NSDictionary *)args callback:(RCTResponseSenderBlock)c
     NSError* error = nil;
     if (syncId) {
         [SFSDKReactLogger d:[self class] format:@"reSync with sync id: %@", syncId];
-        __weak typeof(self) weakSelf = self;
+        __weak __typeof__(self) weakSelf = self;
         sync = [[self getSyncManagerInst:args] reSync:syncId updateBlock:^(SFSyncState *sync) {
             [weakSelf handleSyncUpdate:sync withArgs:args callback:callback];
         } error:&error];
     }
     else if (syncName) {
         [SFSDKReactLogger d:[self class] format:@"reSync with sync name: %@", syncName];
-        __weak typeof(self) weakSelf = self;
+        __weak __typeof__(self) weakSelf = self;
         sync = [[self getSyncManagerInst:args] reSyncByName:syncName updateBlock:^(SFSyncState *sync) {
             [weakSelf handleSyncUpdate:sync withArgs:args callback:callback];
         } error:&error];
@@ -144,7 +144,7 @@ RCT_EXPORT_METHOD(cleanResyncGhosts:(NSDictionary *)args callback:(RCTResponseSe
 {
     NSNumber* syncId = (NSNumber*) [args sfsdk_nonNullObjectForKey:kSyncIdArg];
     [SFSDKReactLogger d:[self class] format:@"cleanResyncGhosts with sync id: %@", syncId];
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     NSError* error = nil;
     [[self getSyncManagerInst:args] cleanResyncGhosts:syncId completionStatusBlock:^void(SFSyncStateStatus syncStatus, NSUInteger numRecords){
         [weakSelf handleCleanReSyncGhosts:syncStatus numRecords:numRecords callback:callback];
@@ -162,7 +162,7 @@ RCT_EXPORT_METHOD(syncUp:(NSDictionary *)args callback:(RCTResponseSenderBlock)c
     NSString *soupName = [args sfsdk_nonNullObjectForKey:kSyncSoupNameArg];
     SFSyncOptions *options = [SFSyncOptions newFromDict:[args sfsdk_nonNullObjectForKey:kSyncOptionsArg]];
     SFSyncUpTarget *target = [SFSyncUpTarget newFromDict:[args sfsdk_nonNullObjectForKey:kSyncTargetArg]];
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     NSError* error = nil;
     SFSyncState* sync = [[self getSyncManagerInst:args] syncUpWithTarget:target options:options soupName:soupName syncName:syncName updateBlock:^(SFSyncState* sync) {
         [weakSelf handleSyncUpdate:sync withArgs:args callback:callback];

--- a/ios/SalesforceReact/SFMobileSyncReactBridge.mm
+++ b/ios/SalesforceReact/SFMobileSyncReactBridge.mm
@@ -31,6 +31,10 @@
 #import <MobileSync/SFMobileSyncSyncManager.h>
 #import <MobileSync/SFSyncState.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <ReactCommon/RCTTurboModule.h>
+#endif
+
 // Private constants
 NSString * const kSyncSoupNameArg = @"soupName";
 NSString * const kSyncTargetArg = @"target";
@@ -233,5 +237,12 @@ RCT_EXPORT_METHOD(syncUp:(NSDictionary *)args callback:(RCTResponseSenderBlock)c
     }
     return storeName;
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeSFMobileSyncReactBridgeSpecJSI>(params);
+}
+#endif
 
 @end

--- a/ios/SalesforceReact/SFNetReactBridge.h
+++ b/ios/SalesforceReact/SFNetReactBridge.h
@@ -24,9 +24,17 @@
 
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNSalesforceReactSpec/RNSalesforceReactSpec.h>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface SFNetReactBridge : NSObject <RCTBridgeModule, NativeSFNetReactBridgeSpec>
+#else
 @interface SFNetReactBridge : NSObject <RCTBridgeModule>
+#endif
 
 @end
 

--- a/ios/SalesforceReact/SFNetReactBridge.mm
+++ b/ios/SalesforceReact/SFNetReactBridge.mm
@@ -26,6 +26,10 @@
 #import <React/RCTUtils.h>
 @import SalesforceSDKCore;
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <ReactCommon/RCTTurboModule.h>
+#endif
+
 
 // Private constants
 static NSString * const kMethodArg       = @"method";
@@ -149,5 +153,12 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
     }
     return result;
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeSFNetReactBridgeSpecJSI>(params);
+}
+#endif
 
 @end

--- a/ios/SalesforceReact/SFNetReactBridge.mm
+++ b/ios/SalesforceReact/SFNetReactBridge.mm
@@ -24,7 +24,14 @@
 
 #import "SFNetReactBridge.h"
 #import <React/RCTUtils.h>
-@import SalesforceSDKCore;
+// NOTE: We use individual #import directives instead of @import here because
+// @import inside an Objective-C++ (.mm) translation unit pulls C++ module
+// support that ends up duplicating libfmt / RCT-Folly symbols across .o files.
+#import <SalesforceSDKCore/SFRestAPI.h>
+#import <SalesforceSDKCore/SFRestRequest.h>
+#import <SalesforceSDKCore/NSDictionary+SFAdditions.h>
+#import <SalesforceSDKCore/NSURLResponse+SFAdditions.h>
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <ReactCommon/RCTTurboModule.h>
@@ -104,10 +111,10 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
     }
     SFRestAPI *restApiInstance = doesNotRequireAuthentication ? [SFRestAPI sharedGlobalInstance] : [SFRestAPI sharedInstance];
 
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     [restApiInstance sendRequest:request
                                       failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
-                                          __strong typeof(self) strongSelf = weakSelf;
+                                          __strong __typeof__(self) strongSelf = weakSelf;
                                           NSMutableDictionary *responseDictionary = [[rawResponse sfsdk_asDictionary] mutableCopy];
                                           responseDictionary[@"body"] = [strongSelf serializableResponse:response rawResponse:rawResponse];
                                           NSMutableDictionary *errorDictionary = [NSMutableDictionary new];
@@ -127,7 +134,7 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
                                       }
                                       // Some response
                                       else if (response) {
-                                          __strong typeof(self) strongSelf = weakSelf;
+                                          __strong __typeof__(self) strongSelf = weakSelf;
                                           result = [strongSelf serializableResponse:response rawResponse:rawResponse];
                                       }
                                       // No response

--- a/ios/SalesforceReact/SFOauthReactBridge.h
+++ b/ios/SalesforceReact/SFOauthReactBridge.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2015-present, salesforce.com, inc. All rights reserved.
- 
+
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions
@@ -11,7 +11,7 @@
  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
  endorse or promote products derived from this software without specific prior written
  permission of salesforce.com, inc.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
@@ -24,9 +24,17 @@
 
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNSalesforceReactSpec/RNSalesforceReactSpec.h>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface SFOauthReactBridge : NSObject <RCTBridgeModule, NativeSFOauthReactBridgeSpec>
+#else
 @interface SFOauthReactBridge : NSObject <RCTBridgeModule>
+#endif
 
 @end
 

--- a/ios/SalesforceReact/SFOauthReactBridge.mm
+++ b/ios/SalesforceReact/SFOauthReactBridge.mm
@@ -27,6 +27,10 @@
 #import <React/RCTUtils.h>
 #import <SalesforceSDKCore/SalesforceSDKManager.h>
 #import <SalesforceSDKCore/SFUserAccountManager.h>
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <ReactCommon/RCTTurboModule.h>
+#endif
 NSString * const kAccessTokenCredentialsDictKey = @"accessToken";
 NSString * const kRefreshTokenCredentialsDictKey = @"refreshToken";
 NSString * const kClientIdCredentialsDictKey = @"clientId";
@@ -117,7 +121,7 @@ RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderB
 {
     SFOAuthCredentials *creds = [SFUserAccountManager sharedInstance].currentUser.credentials;
     NSString *accessToken = creds.accessToken;
-    
+
     // If access token is not present, send error so user can manually authenticate. Otherwise, send current credentials.
     if (accessToken) {
         [self sendAuthCredentials:callback];
@@ -125,4 +129,12 @@ RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderB
         [self sendNotAuthenticatedError:callback];
     }
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeSFOauthReactBridgeSpecJSI>(params);
+}
+#endif
+
 @end

--- a/ios/SalesforceReact/SFOauthReactBridge.mm
+++ b/ios/SalesforceReact/SFOauthReactBridge.mm
@@ -75,10 +75,11 @@ RCT_EXPORT_METHOD(logoutCurrentUser:(NSDictionary *)args callback:(RCTResponseSe
 
 RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
-    __weak typeof(self) weakSelf = self;
+    // Use __typeof__ instead of typeof for Objective-C++ compatibility.
+    __weak __typeof__(self) weakSelf = self;
     [SFSDKReactLogger d:[self class] format:@"authenticate: arguments: %@", args];
     dispatch_async(dispatch_get_main_queue(), ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
+        __strong __typeof__(weakSelf) strongSelf = weakSelf;
         [[SFUserAccountManager sharedInstance] loginWithCompletion:^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {
             [SFUserAccountManager sharedInstance].currentUser  =  userAccount;
             [strongSelf sendAuthCredentials:callback];

--- a/ios/SalesforceReact/SFSmartStoreReactBridge.h
+++ b/ios/SalesforceReact/SFSmartStoreReactBridge.h
@@ -24,9 +24,17 @@
 
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNSalesforceReactSpec/RNSalesforceReactSpec.h>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface SFSmartStoreReactBridge : NSObject <RCTBridgeModule, NativeSFSmartStoreReactBridgeSpec>
+#else
 @interface SFSmartStoreReactBridge : NSObject <RCTBridgeModule>
+#endif
 
 @end
 

--- a/ios/SalesforceReact/SFSmartStoreReactBridge.mm
+++ b/ios/SalesforceReact/SFSmartStoreReactBridge.mm
@@ -27,6 +27,10 @@
 #import <React/RCTUtils.h>
 #import <SalesforceSDKCore/NSDictionary+SFAdditions.h>
 #import <SalesforceSDKCommon/SFJsonUtils.h>
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <ReactCommon/RCTTurboModule.h>
+#endif
 #import <SmartStore/SFStoreCursor.h>
 #import <SmartStore/SFSmartStore.h>
 #import <SmartStore/SFQuerySpec.h>
@@ -431,5 +435,12 @@ RCT_EXPORT_METHOD(removeAllStores:(NSDictionary *)argsDict callback:(RCTResponse
     NSString *internalCursorId = [NSString stringWithFormat:@"%@_%@_%d",storeName,cursorId,isGlobal];
     return internalCursorId;
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeSFSmartStoreReactBridgeSpecJSI>(params);
+}
+#endif
 
 @end

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.1.0",
     "react-native": "0.81.5",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration"
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
   },
   "devDependencies": {
     "chai": "4.4.1",

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.1.0",
     "react-native": "0.81.5",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration"
   },
   "devDependencies": {
     "chai": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,14 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "codegenConfig": {
+    "name": "RNSalesforceReactSpec",
+    "type": "modules",
+    "jsSrcsDir": "src/specs",
+    "android": {
+      "javaPackageName": "com.salesforce.androidsdk.reactnative.generated"
+    }
+  },
   "scripts": {
     "build": "tsc --build",
     "prepublish": "npm run build"

--- a/src/react.force.mobilesync.ts
+++ b/src/react.force.mobilesync.ts
@@ -23,12 +23,16 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-import { NativeModules } from "react-native";
+import { NativeModules, TurboModuleRegistry } from "react-native";
 import { exec as forceExec, ExecErrorCallback, ExecSuccessCallback } from "./react.force.common";
 import { StoreConfig } from "./react.force.smartstore";
 import { SyncDownTarget, SyncEvent, SyncMethod, SyncOptions, SyncStatus, SyncUpTarget } from "./typings/mobilesync";
 
-const { MobileSyncReactBridge, SFMobileSyncReactBridge } = NativeModules;
+// New architecture: TurboModuleRegistry first, fall back to NativeModules.
+const SFMobileSyncReactBridge =
+  TurboModuleRegistry.get<any>("SFMobileSyncReactBridge") ?? NativeModules.SFMobileSyncReactBridge;
+const MobileSyncReactBridge =
+  TurboModuleRegistry.get<any>("MobileSyncReactBridge") ?? NativeModules.MobileSyncReactBridge;
 
 // If param is a storeconfig return the same storeconfig
 // If param is a boolean, returns a storeconfig object  {'isGlobalStore': boolean}

--- a/src/react.force.net.ts
+++ b/src/react.force.net.ts
@@ -24,10 +24,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { NativeModules } from "react-native";
+import { NativeModules, TurboModuleRegistry } from "react-native";
 import { exec as forceExec, ExecErrorCallback, ExecSuccessCallback } from "./react.force.common";
 import { HttpMethod } from "./typings";
-const { SalesforceNetReactBridge, SFNetReactBridge } = NativeModules;
+
+// New architecture: TurboModuleRegistry first, fall back to NativeModules.
+const SFNetReactBridge =
+  TurboModuleRegistry.get<any>("SFNetReactBridge") ?? NativeModules.SFNetReactBridge;
+const SalesforceNetReactBridge =
+  TurboModuleRegistry.get<any>("SalesforceNetReactBridge") ??
+  NativeModules.SalesforceNetReactBridge;
 
 var  apiVersion = 'v66.0';
 

--- a/src/react.force.oauth.ts
+++ b/src/react.force.oauth.ts
@@ -24,10 +24,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { NativeModules } from "react-native";
+import { NativeModules, TurboModuleRegistry } from "react-native";
 import { exec as forceExec, ExecSuccessCallback, ExecErrorCallback } from "./react.force.common";
 import { OAuthMethod, UserAccount } from "./typings/oauth";
-const { SalesforceOauthReactBridge, SFOauthReactBridge } = NativeModules;
+
+// New architecture: TurboModuleRegistry returns the module if registered as a
+// TurboModule. Falls back to NativeModules (legacy bridge / interop mode).
+const SFOauthReactBridge =
+  TurboModuleRegistry.get<any>("SFOauthReactBridge") ?? NativeModules.SFOauthReactBridge;
+const SalesforceOauthReactBridge =
+  TurboModuleRegistry.get<any>("SalesforceOauthReactBridge") ??
+  NativeModules.SalesforceOauthReactBridge;
 
 const exec = <T>(
   successCB: ExecSuccessCallback<T>,

--- a/src/react.force.smartstore.ts
+++ b/src/react.force.smartstore.ts
@@ -24,11 +24,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { NativeModules } from "react-native";
+import { NativeModules, TurboModuleRegistry } from "react-native";
 import { exec as forceExec, ExecErrorCallback, ExecSuccessCallback, safeJSONparse } from "./react.force.common";
 import { QuerySpecType, StoreOrder } from "./typings";
 import { SmartStoreMethod } from "./typings/smartstore";
-const { SmartStoreReactBridge, SFSmartStoreReactBridge } = NativeModules;
+
+// New architecture: TurboModuleRegistry first, fall back to NativeModules.
+const SFSmartStoreReactBridge =
+  TurboModuleRegistry.get<any>("SFSmartStoreReactBridge") ?? NativeModules.SFSmartStoreReactBridge;
+const SmartStoreReactBridge =
+  TurboModuleRegistry.get<any>("SmartStoreReactBridge") ?? NativeModules.SmartStoreReactBridge;
 
 const exec = <T>(
   successCB: ExecSuccessCallback<T>,

--- a/src/specs/NativeSFMobileSyncReactBridge.ts
+++ b/src/specs/NativeSFMobileSyncReactBridge.ts
@@ -7,23 +7,16 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
-type SyncArgs = {
-  isGlobalStore?: boolean;
-  storeName?: string;
-  soupName?: string;
-  target?: Object;
-  options?: Object;
-  syncName?: string;
-  syncId?: number;
-};
+// Actual args shape for all MobileSync methods:
+//   { isGlobalStore?, storeName?, soupName?, target?, options?, syncName?, syncId? }
 
 export interface Spec extends TurboModule {
-  syncDown(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  syncUp(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  reSync(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  getSyncStatus(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  deleteSync(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  cleanResyncGhosts(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  syncDown(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  syncUp(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  reSync(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getSyncStatus(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  deleteSync(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  cleanResyncGhosts(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
 }
 
 export default TurboModuleRegistry.get<Spec>("SFMobileSyncReactBridge");

--- a/src/specs/NativeSFMobileSyncReactBridge.ts
+++ b/src/specs/NativeSFMobileSyncReactBridge.ts
@@ -7,20 +7,23 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
-/**
- * TurboModule spec for MobileSync bridge.
- *
- * Maps to:
- * - iOS native module name: "SFMobileSyncReactBridge"
- * - Android native module name: "MobileSyncReactBridge"
- */
+type SyncArgs = {
+  isGlobalStore?: boolean;
+  storeName?: string;
+  soupName?: string;
+  target?: Object;
+  options?: Object;
+  syncName?: string;
+  syncId?: number;
+};
+
 export interface Spec extends TurboModule {
-  syncDown(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  syncUp(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  reSync(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  getSyncStatus(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  deleteSync(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  cleanResyncGhosts(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  syncDown(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  syncUp(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  reSync(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  getSyncStatus(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  deleteSync(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  cleanResyncGhosts(args: SyncArgs, callback: (error: Object | null, result: Object | null) => void): void;
 }
 
 export default TurboModuleRegistry.get<Spec>("SFMobileSyncReactBridge");

--- a/src/specs/NativeSFMobileSyncReactBridge.ts
+++ b/src/specs/NativeSFMobileSyncReactBridge.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+
+/**
+ * TurboModule spec for MobileSync bridge.
+ *
+ * Maps to:
+ * - iOS native module name: "SFMobileSyncReactBridge"
+ * - Android native module name: "MobileSyncReactBridge"
+ */
+export interface Spec extends TurboModule {
+  syncDown(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  syncUp(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  reSync(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getSyncStatus(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  deleteSync(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  cleanResyncGhosts(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+}
+
+export default TurboModuleRegistry.get<Spec>("SFMobileSyncReactBridge");

--- a/src/specs/NativeSFNetReactBridge.ts
+++ b/src/specs/NativeSFNetReactBridge.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+
+/**
+ * TurboModule spec for Net (REST) bridge.
+ *
+ * Maps to:
+ * - iOS native module name: "SFNetReactBridge"
+ * - Android native module name: "SalesforceNetReactBridge"
+ */
+export interface Spec extends TurboModule {
+  sendRequest(
+    args: Object,
+    callback: (error: Object | null, result: Object | null) => void,
+  ): void;
+}
+
+export default TurboModuleRegistry.get<Spec>("SFNetReactBridge");

--- a/src/specs/NativeSFNetReactBridge.ts
+++ b/src/specs/NativeSFNetReactBridge.ts
@@ -7,20 +7,12 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
+// Actual args shape for sendRequest:
+//   { endPoint, path, method, queryParams, headerParams, fileParams,
+//     returnBinary, doesNotRequireAuthentication }
+
 export interface Spec extends TurboModule {
-  sendRequest(
-    args: {
-      endPoint: string;
-      path: string;
-      method: string;
-      queryParams?: Object | null;
-      headerParams?: Object | null;
-      fileParams?: Object | null;
-      returnBinary?: boolean;
-      doesNotRequireAuthentication?: boolean;
-    },
-    callback: (error: Object | null, result: Object | null) => void,
-  ): void;
+  sendRequest(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
 }
 
 export default TurboModuleRegistry.get<Spec>("SFNetReactBridge");

--- a/src/specs/NativeSFNetReactBridge.ts
+++ b/src/specs/NativeSFNetReactBridge.ts
@@ -7,16 +7,18 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
-/**
- * TurboModule spec for Net (REST) bridge.
- *
- * Maps to:
- * - iOS native module name: "SFNetReactBridge"
- * - Android native module name: "SalesforceNetReactBridge"
- */
 export interface Spec extends TurboModule {
   sendRequest(
-    args: Object,
+    args: {
+      endPoint: string;
+      path: string;
+      method: string;
+      queryParams?: Object | null;
+      headerParams?: Object | null;
+      fileParams?: Object | null;
+      returnBinary?: boolean;
+      doesNotRequireAuthentication?: boolean;
+    },
     callback: (error: Object | null, result: Object | null) => void,
   ): void;
 }

--- a/src/specs/NativeSFOauthReactBridge.ts
+++ b/src/specs/NativeSFOauthReactBridge.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+
+/**
+ * TurboModule spec for OAuth bridge.
+ *
+ * Maps to:
+ * - iOS native module name: "SFOauthReactBridge"
+ * - Android native module name: "SalesforceOauthReactBridge"
+ *
+ * All methods use the legacy Node-style callback `(error, result)`
+ * to preserve the existing JS-side `react.force.common#exec` contract.
+ */
+export interface Spec extends TurboModule {
+  getAuthCredentials(
+    args: Object,
+    callback: (error: Object | null, result: Object | null) => void,
+  ): void;
+
+  authenticate(
+    args: Object,
+    callback: (error: Object | null, result: Object | null) => void,
+  ): void;
+
+  logoutCurrentUser(
+    args: Object,
+    callback: (error: Object | null, result: Object | null) => void,
+  ): void;
+}
+
+export default TurboModuleRegistry.get<Spec>("SFOauthReactBridge");

--- a/src/specs/NativeSFOauthReactBridge.ts
+++ b/src/specs/NativeSFOauthReactBridge.ts
@@ -7,29 +7,19 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
-/**
- * TurboModule spec for OAuth bridge.
- *
- * Maps to:
- * - iOS native module name: "SFOauthReactBridge"
- * - Android native module name: "SalesforceOauthReactBridge"
- *
- * All methods use the legacy Node-style callback `(error, result)`
- * to preserve the existing JS-side `react.force.common#exec` contract.
- */
 export interface Spec extends TurboModule {
   getAuthCredentials(
-    args: Object,
+    args: {},
     callback: (error: Object | null, result: Object | null) => void,
   ): void;
 
   authenticate(
-    args: Object,
+    args: {},
     callback: (error: Object | null, result: Object | null) => void,
   ): void;
 
   logoutCurrentUser(
-    args: Object,
+    args: {},
     callback: (error: Object | null, result: Object | null) => void,
   ): void;
 }

--- a/src/specs/NativeSFOauthReactBridge.ts
+++ b/src/specs/NativeSFOauthReactBridge.ts
@@ -7,21 +7,19 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
+// Codegen requires `Object` for args to generate `NSDictionary *` (iOS) /
+// `ReadableMap` (Android). Using inline typed objects causes Codegen to
+// generate C++ structs that don't match our existing native signatures.
+//
+// Actual args shapes (for documentation, not enforced by Codegen):
+//   getAuthCredentials: {} (empty)
+//   authenticate: {} (empty)
+//   logoutCurrentUser: {} (empty)
+
 export interface Spec extends TurboModule {
-  getAuthCredentials(
-    args: {},
-    callback: (error: Object | null, result: Object | null) => void,
-  ): void;
-
-  authenticate(
-    args: {},
-    callback: (error: Object | null, result: Object | null) => void,
-  ): void;
-
-  logoutCurrentUser(
-    args: {},
-    callback: (error: Object | null, result: Object | null) => void,
-  ): void;
+  getAuthCredentials(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  authenticate(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  logoutCurrentUser(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
 }
 
 export default TurboModuleRegistry.get<Spec>("SFOauthReactBridge");

--- a/src/specs/NativeSFSmartStoreReactBridge.ts
+++ b/src/specs/NativeSFSmartStoreReactBridge.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+
+/**
+ * TurboModule spec for SmartStore bridge.
+ *
+ * Maps to:
+ * - iOS native module name: "SFSmartStoreReactBridge"
+ * - Android native module name: "SmartStoreReactBridge"
+ */
+export interface Spec extends TurboModule {
+  // Soup management
+  soupExists(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  registerSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getSoupIndexSpecs(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  alterSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  reIndexSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  clearSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+
+  // CRUD operations
+  upsertSoupEntries(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  retrieveSoupEntries(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeFromSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+
+  // Query operations
+  querySoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  runSmartQuery(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  moveCursorToPageIndex(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  closeCursor(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+
+  // Database / store management
+  getDatabaseSize(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getAllStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getAllGlobalStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeStore(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeAllStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeAllGlobalStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+}
+
+export default TurboModuleRegistry.get<Spec>("SFSmartStoreReactBridge");

--- a/src/specs/NativeSFSmartStoreReactBridge.ts
+++ b/src/specs/NativeSFSmartStoreReactBridge.ts
@@ -7,41 +7,39 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
-/**
- * TurboModule spec for SmartStore bridge.
- *
- * Maps to:
- * - iOS native module name: "SFSmartStoreReactBridge"
- * - Android native module name: "SmartStoreReactBridge"
- */
+type StoreArgs = {
+  isGlobalStore?: boolean;
+  storeName?: string;
+};
+
+type SoupArgs = StoreArgs & {
+  soupName?: string;
+};
+
 export interface Spec extends TurboModule {
-  // Soup management
-  soupExists(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  registerSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  removeSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  getSoupIndexSpecs(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  alterSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  reIndexSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  clearSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  soupExists(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  registerSoup(args: SoupArgs & { indexes?: Array<Object> }, callback: (error: Object | null, result: Object | null) => void): void;
+  removeSoup(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  getSoupIndexSpecs(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  alterSoup(args: SoupArgs & { indexes?: Array<Object>; reIndexData?: boolean }, callback: (error: Object | null, result: Object | null) => void): void;
+  reIndexSoup(args: SoupArgs & { paths?: Array<string> }, callback: (error: Object | null, result: Object | null) => void): void;
+  clearSoup(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
 
-  // CRUD operations
-  upsertSoupEntries(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  retrieveSoupEntries(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  removeFromSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  upsertSoupEntries(args: SoupArgs & { entries?: Array<Object>; externalIdPath?: string }, callback: (error: Object | null, result: Object | null) => void): void;
+  retrieveSoupEntries(args: SoupArgs & { entryIds?: Array<number> }, callback: (error: Object | null, result: Object | null) => void): void;
+  removeFromSoup(args: SoupArgs & { entryIds?: Array<number>; querySpec?: Object; soupEntryIds?: Array<number> }, callback: (error: Object | null, result: Object | null) => void): void;
 
-  // Query operations
-  querySoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  runSmartQuery(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  moveCursorToPageIndex(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  closeCursor(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  querySoup(args: SoupArgs & { querySpec?: Object }, callback: (error: Object | null, result: Object | null) => void): void;
+  runSmartQuery(args: SoupArgs & { querySpec?: Object }, callback: (error: Object | null, result: Object | null) => void): void;
+  moveCursorToPageIndex(args: StoreArgs & { cursorId?: string; index?: number }, callback: (error: Object | null, result: Object | null) => void): void;
+  closeCursor(args: StoreArgs & { cursorId?: string }, callback: (error: Object | null, result: Object | null) => void): void;
 
-  // Database / store management
-  getDatabaseSize(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  getAllStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  getAllGlobalStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  removeStore(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  removeAllStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
-  removeAllGlobalStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getDatabaseSize(args: StoreArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  getAllStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
+  getAllGlobalStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
+  removeStore(args: StoreArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  removeAllStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
+  removeAllGlobalStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
 }
 
 export default TurboModuleRegistry.get<Spec>("SFSmartStoreReactBridge");

--- a/src/specs/NativeSFSmartStoreReactBridge.ts
+++ b/src/specs/NativeSFSmartStoreReactBridge.ts
@@ -7,39 +7,45 @@
 import type { TurboModule } from "react-native";
 import { TurboModuleRegistry } from "react-native";
 
-type StoreArgs = {
-  isGlobalStore?: boolean;
-  storeName?: string;
-};
-
-type SoupArgs = StoreArgs & {
-  soupName?: string;
-};
+// Common args shapes (for documentation):
+//   StoreArgs: { isGlobalStore?, storeName? }
+//   SoupArgs:  StoreArgs + { soupName? }
+//
+// Method-specific args include additional fields like:
+//   registerSoup: + { indexes }
+//   querySoup/runSmartQuery: + { querySpec }
+//   upsertSoupEntries: + { entries, externalIdPath? }
+//   retrieveSoupEntries: + { entryIds }
+//   removeFromSoup: + { entryIds?, querySpec?, soupEntryIds? }
+//   moveCursorToPageIndex: + { cursorId, index }
+//   closeCursor: + { cursorId }
+//   alterSoup: + { indexes, reIndexData? }
+//   reIndexSoup: + { paths }
 
 export interface Spec extends TurboModule {
-  soupExists(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  registerSoup(args: SoupArgs & { indexes?: Array<Object> }, callback: (error: Object | null, result: Object | null) => void): void;
-  removeSoup(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  getSoupIndexSpecs(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  alterSoup(args: SoupArgs & { indexes?: Array<Object>; reIndexData?: boolean }, callback: (error: Object | null, result: Object | null) => void): void;
-  reIndexSoup(args: SoupArgs & { paths?: Array<string> }, callback: (error: Object | null, result: Object | null) => void): void;
-  clearSoup(args: SoupArgs, callback: (error: Object | null, result: Object | null) => void): void;
+  soupExists(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  registerSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getSoupIndexSpecs(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  alterSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  reIndexSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  clearSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
 
-  upsertSoupEntries(args: SoupArgs & { entries?: Array<Object>; externalIdPath?: string }, callback: (error: Object | null, result: Object | null) => void): void;
-  retrieveSoupEntries(args: SoupArgs & { entryIds?: Array<number> }, callback: (error: Object | null, result: Object | null) => void): void;
-  removeFromSoup(args: SoupArgs & { entryIds?: Array<number>; querySpec?: Object; soupEntryIds?: Array<number> }, callback: (error: Object | null, result: Object | null) => void): void;
+  upsertSoupEntries(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  retrieveSoupEntries(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeFromSoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
 
-  querySoup(args: SoupArgs & { querySpec?: Object }, callback: (error: Object | null, result: Object | null) => void): void;
-  runSmartQuery(args: SoupArgs & { querySpec?: Object }, callback: (error: Object | null, result: Object | null) => void): void;
-  moveCursorToPageIndex(args: StoreArgs & { cursorId?: string; index?: number }, callback: (error: Object | null, result: Object | null) => void): void;
-  closeCursor(args: StoreArgs & { cursorId?: string }, callback: (error: Object | null, result: Object | null) => void): void;
+  querySoup(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  runSmartQuery(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  moveCursorToPageIndex(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  closeCursor(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
 
-  getDatabaseSize(args: StoreArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  getAllStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
-  getAllGlobalStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
-  removeStore(args: StoreArgs, callback: (error: Object | null, result: Object | null) => void): void;
-  removeAllStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
-  removeAllGlobalStores(args: {}, callback: (error: Object | null, result: Object | null) => void): void;
+  getDatabaseSize(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getAllStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  getAllGlobalStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeStore(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeAllStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
+  removeAllGlobalStores(args: Object, callback: (error: Object | null, result: Object | null) => void): void;
 }
 
 export default TurboModuleRegistry.get<Spec>("SFSmartStoreReactBridge");


### PR DESCRIPTION
## Summary

Migrates the iOS bridge modules to React Native's New Architecture (TurboModules) with Codegen support. After this change, bridges run through direct JSI dispatch instead of the legacy JSON-serialization bridge.

**Verified:** 35/35 iOS tests pass with `RCT_NEW_ARCH_ENABLED=1` using clean Codegen (not interop mode).

## Changes

### Phase 1: Codegen Specs + JS TurboModule Lookup
- Added `codegenConfig` to `package.json` (name: `RNSalesforceReactSpec`)
- Created TurboModule specs: `src/specs/NativeSF{Oauth,Net,SmartStore,MobileSync}ReactBridge.ts`
- Updated `src/react.force.{oauth,net,smartstore,mobilesync}.ts` to use `TurboModuleRegistry.get()` with `NativeModules` fallback

### Phase 2: iOS Bridge Implementation
- Renamed `.m` → `.mm` for all 4 bridge files (C++ required for TurboModule JSI headers)
- Updated headers with conditional `NativeSF*BridgeSpec` protocol conformance (`#ifdef RCT_NEW_ARCH_ENABLED`)
- Added `getTurboModule:` method to each bridge (returns Codegen-generated JSI wrapper)
- Fixed C++ compatibility: `typeof()` → `__typeof__()`, `@import` → explicit `#import` for SFNetReactBridge
- Updated `SalesforceReact.podspec`: `.mm` in source_files, `install_modules_dependencies()`, `c++20`

## How it works

1. `codegenConfig` in `package.json` tells React Native's `react_native_pods.rb` to run Codegen during `pod install`
2. Codegen generates `RNSalesforceReactSpec.h` (ObjC protocol) + `NativeSF*BridgeSpecJSI` (C++ JSI wrappers)
3. Bridge headers conform to the generated protocol under `#ifdef RCT_NEW_ARCH_ENABLED`
4. At runtime, RN calls `getTurboModule:` which returns the JSI wrapper → direct native calls, no JSON serialization

## ⚠️ Before merging

Revert `iosTests/package.json` dependency back to `forcedotcom#dev`:
```diff
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration"
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
```
(Currently pointing at this branch so CI can pick up `codegenConfig` for the test build. Once merged to dev, dev will have it natively.)

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] iOS tests pass with new architecture: 35/35 (0 failures)
- [x] Codegen generates correct `NSDictionary *` / `RCTResponseSenderBlock` protocol
- [x] All 4 RN templates build on iOS with this branch (`test_template.sh`)
- [ ] CI passes
- [ ] Review: confirm no public API changes (JS surface is identical)