### PR TITLE
React Native New Architecture: Unified callback pattern

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,16 @@
+// Stub Android library for React Native autolinking.
+// The actual native implementation lives in SalesforceMobileSDK-Android/libs/SalesforceReact
+// and is included via composite build (includeBuild in settings.gradle).
+// This stub only exists so that the RN CLI detects react-native-force as an
+// Android native module and includes SalesforceReactPackage in the auto-generated PackageList.
+
+apply plugin: 'com.android.library'
+
+android {
+    namespace "com.salesforce.androidsdk.reactnative"
+    compileSdk 36
+
+    defaultConfig {
+        minSdk 28
+    }
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.salesforce.androidsdk.reactnative">
+</manifest>

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,29 @@
 "use strict";
+/*
+ * Copyright (c) 2016-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -50,4 +75,3 @@ const forceUtil = __importStar(require("./react.force.util"));
 exports.forceUtil = forceUtil;
 const forceClient = net;
 exports.forceClient = forceClient;
-//# sourceMappingURL=index.js.map

--- a/dist/react.force.common.d.ts
+++ b/dist/react.force.common.d.ts
@@ -1,15 +1,27 @@
 import { ModuleAndroidName, ModuleIOSName } from "./typings";
-export type iOSModuleCallback<T> = (err: Error, result: T) => void;
-export type AndroidSuccessCallback = (result: string) => void;
-export type AndroidErrorCallback = (err: string) => void;
+/**
+ * Represents an exec() success callback
+ */
 export type ExecSuccessCallback<T> = (result: T) => void;
+/**
+ * Represents an exec() error callback
+ */
 export type ExecErrorCallback = (err: Error) => void;
-interface ModuleIOS<T> {
-    [key: string]: (args: unknown, callback: iOSModuleCallback<T>) => void;
+/**
+ * Represents a native module with unified single-callback pattern.
+ * Both iOS and Android now use: module.method(args, (error, result) => {...})
+ */
+interface NativeModule {
+    [key: string]: (args: unknown, callback: (error: any, result: any) => void) => void;
 }
-interface ModuleAndroid {
-    [key: string]: (args: unknown, successCB: AndroidSuccessCallback, errorCB: AndroidErrorCallback) => void;
-}
-export declare const exec: <T>(moduleIOSName: ModuleIOSName, moduleAndroidName: ModuleAndroidName, moduleIOS: ModuleIOS<T>, moduleAndroid: ModuleAndroid, successCB: ExecSuccessCallback<T> | null, errorCB: ExecErrorCallback | null, methodName: string, args: Record<string, unknown>) => void;
+/**
+ * Executes an action using the React Native Mobile SDK Bridge.
+ * Both iOS and Android use a unified single-callback pattern:
+ * callback(error, result) where error is null on success.
+ */
+export declare const exec: <T>(moduleIOSName: ModuleIOSName, moduleAndroidName: ModuleAndroidName, moduleIOS: NativeModule, moduleAndroid: NativeModule, successCB: ExecSuccessCallback<T> | null, errorCB: ExecErrorCallback | null, methodName: string, args: Record<string, unknown>) => void;
+/**
+ * Parses a JSON string safely, returning the original value if parsing fails.
+ */
 export declare const safeJSONparse: <T>(str: string) => T;
 export {};

--- a/dist/react.force.common.js
+++ b/dist/react.force.common.js
@@ -1,47 +1,72 @@
 "use strict";
+/*
+ * Copyright (c) 2015-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.safeJSONparse = exports.exec = void 0;
 const react_force_log_1 = require("./react.force.log");
+/**
+ * Executes an action using the React Native Mobile SDK Bridge.
+ * Both iOS and Android use a unified single-callback pattern:
+ * callback(error, result) where error is null on success.
+ */
 const exec = (moduleIOSName, moduleAndroidName, moduleIOS, moduleAndroid, successCB, errorCB, methodName, args) => {
-    if (moduleIOS) {
-        const func = `${moduleIOSName}.${methodName}`;
-        react_force_log_1.sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
-        moduleIOS[methodName](args, (error, result) => {
-            if (error) {
-                react_force_log_1.sdkConsole.error(`${func} failed: ${JSON.stringify(error)}`);
-                if (errorCB)
-                    errorCB(error);
-            }
-            else {
-                react_force_log_1.sdkConsole.debug(`${func} succeeded`);
-                if (successCB)
-                    successCB(result);
-            }
-        });
+    const module = moduleIOS !== null && moduleIOS !== void 0 ? moduleIOS : moduleAndroid;
+    const moduleName = moduleIOS ? moduleIOSName : moduleAndroidName;
+    if (!module) {
+        react_force_log_1.sdkConsole.error(`No native module found for ${moduleIOSName}/${moduleAndroidName}`);
+        if (errorCB)
+            errorCB(new Error("Native module not available"));
+        return;
     }
-    else if (moduleAndroid) {
-        const func = `${moduleAndroidName}.${methodName}`;
-        react_force_log_1.sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
-        moduleAndroid[methodName](args, (result) => {
-            react_force_log_1.sdkConsole.debug(`${func} succeeded`);
-            if (successCB) {
-                successCB((0, exports.safeJSONparse)(result));
-            }
-        }, (error) => {
+    const func = `${moduleName}.${methodName}`;
+    react_force_log_1.sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
+    module[methodName](args, (error, result) => {
+        if (error) {
             react_force_log_1.sdkConsole.error(`${func} failed: ${JSON.stringify(error)}`);
             if (errorCB)
-                errorCB((0, exports.safeJSONparse)(error));
-        });
-    }
+                errorCB(typeof error === "string" ? (0, exports.safeJSONparse)(error) : error);
+        }
+        else {
+            react_force_log_1.sdkConsole.debug(`${func} succeeded`);
+            if (successCB)
+                successCB(typeof result === "string" ? (0, exports.safeJSONparse)(result) : result);
+        }
+    });
 };
 exports.exec = exec;
+/**
+ * Parses a JSON string safely, returning the original value if parsing fails.
+ */
 const safeJSONparse = (str) => {
     try {
         return JSON.parse(str);
     }
     catch (e) {
+        // @ts-ignore
         return str;
     }
 };
 exports.safeJSONparse = safeJSONparse;
-//# sourceMappingURL=react.force.common.js.map

--- a/dist/react.force.log.js
+++ b/dist/react.force.log.js
@@ -1,6 +1,34 @@
 "use strict";
+/*
+ * Copyright (c) 2020-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setLogLevel = exports.sdkConsole = exports.getLogLevel = void 0;
+/**
+ * logging support
+ */
 let logLevel = "info";
 const getLogLevel = () => {
     return logLevel;
@@ -10,8 +38,10 @@ exports.sdkConsole = {
     debug: console.debug.bind(console),
     info: console.info.bind(console),
     warn: () => {
+        /** */
     },
     error: () => {
+        /** */
     },
     log: console.log.bind(console),
 };
@@ -20,13 +50,13 @@ const setLogLevel = (level) => {
     const methods = ["debug", "info", "warn", "error"];
     const levelAsInt = methods.indexOf(level.toLowerCase());
     const noop = () => {
+        /** */
     };
     exports.sdkConsole.debug = levelAsInt <= 0 ? console.debug.bind(console) : noop;
     exports.sdkConsole.info = levelAsInt <= 1 ? console.info.bind(console) : noop;
-    exports.sdkConsole.warn = levelAsInt <= 2 ? console.log.bind(console) : noop;
-    exports.sdkConsole.error = levelAsInt <= 3 ? console.log.bind(console) : noop;
+    exports.sdkConsole.warn = levelAsInt <= 2 ? console.log.bind(console) : noop; // we don't want the yellow box
+    exports.sdkConsole.error = levelAsInt <= 3 ? console.log.bind(console) : noop; // we don't want the red box
     exports.sdkConsole.log = console.log.bind(console);
 };
 exports.setLogLevel = setLogLevel;
 (0, exports.setLogLevel)("info");
-//# sourceMappingURL=react.force.log.js.map

--- a/dist/react.force.mobilesync.js
+++ b/dist/react.force.mobilesync.js
@@ -1,5 +1,4 @@
 "use strict";
-var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.MERGE_MODE = exports.deleteSync = exports.getSyncStatus = exports.syncUp = exports.cleanResyncGhosts = exports.reSync = exports.syncDown = void 0;
 /*
@@ -30,8 +29,9 @@ exports.MERGE_MODE = exports.deleteSync = exports.getSyncStatus = exports.syncUp
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
 // New architecture: TurboModuleRegistry first, fall back to NativeModules.
-const SFMobileSyncReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFMobileSyncReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFMobileSyncReactBridge;
-const MobileSyncReactBridge = (_b = react_native_1.TurboModuleRegistry.get("MobileSyncReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.MobileSyncReactBridge;
+// Lazy lookup - bridgeless mode doesn't have modules ready at import time.
+const getSFMobileSyncReactBridge = () => { var _a; return (_a = react_native_1.TurboModuleRegistry.get("SFMobileSyncReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFMobileSyncReactBridge; };
+const getMobileSyncReactBridge = () => { var _a; return (_a = react_native_1.TurboModuleRegistry.get("MobileSyncReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.MobileSyncReactBridge; };
 // If param is a storeconfig return the same storeconfig
 // If param is a boolean, returns a storeconfig object  {'isGlobalStore': boolean}
 // Otherwise, returns a default storeconfig object
@@ -48,7 +48,7 @@ const checkFirstArg = (arg) => {
     return { isGlobalStore: isGlobalStore };
 };
 const exec = (successCB, errorCB, methodName, args) => {
-    (0, react_force_common_1.exec)("SFMobileSyncReactBridge", "MobileSyncReactBridge", SFMobileSyncReactBridge, MobileSyncReactBridge, successCB, errorCB, methodName, args);
+    (0, react_force_common_1.exec)("SFMobileSyncReactBridge", "MobileSyncReactBridge", getSFMobileSyncReactBridge(), getMobileSyncReactBridge(), successCB, errorCB, methodName, args);
 };
 const syncDown = (storeConfig, target, soupName, options, x, y, z) => {
     storeConfig = checkFirstArg(storeConfig);

--- a/dist/react.force.mobilesync.js
+++ b/dist/react.force.mobilesync.js
@@ -1,10 +1,43 @@
 "use strict";
+var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.MERGE_MODE = exports.deleteSync = exports.getSyncStatus = exports.syncUp = exports.cleanResyncGhosts = exports.reSync = exports.syncDown = void 0;
+/*
+ * Copyright (c) 2015-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
-const { MobileSyncReactBridge, SFMobileSyncReactBridge } = react_native_1.NativeModules;
+// New architecture: TurboModuleRegistry first, fall back to NativeModules.
+const SFMobileSyncReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFMobileSyncReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFMobileSyncReactBridge;
+const MobileSyncReactBridge = (_b = react_native_1.TurboModuleRegistry.get("MobileSyncReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.MobileSyncReactBridge;
+// If param is a storeconfig return the same storeconfig
+// If param is a boolean, returns a storeconfig object  {'isGlobalStore': boolean}
+// Otherwise, returns a default storeconfig object
 const checkFirstArg = (arg) => {
+    // Turning arguments into array
+    // If first argument is a store config
     if (typeof arg === "object" && Object.prototype.hasOwnProperty.call(arg, "isGlobalStore")) {
         return arg;
     }
@@ -22,6 +55,7 @@ const syncDown = (storeConfig, target, soupName, options, x, y, z) => {
     let syncName;
     let successCB;
     let errorCB;
+    // syncName optional (new in 6.0)
     if (typeof x === "function") {
         syncName = undefined;
         successCB = x;
@@ -66,6 +100,7 @@ const syncUp = (storeConfig, target, soupName, options, x, y, z) => {
     let syncName;
     let successCB;
     let errorCB;
+    // syncName optional (new in 6.0)
     if (typeof x === "function") {
         syncName = undefined;
         successCB = x;
@@ -110,4 +145,3 @@ exports.MERGE_MODE = {
     OVERWRITE: "OVERWRITE",
     LEAVE_IF_CHANGED: "LEAVE_IF_CHANGED",
 };
-//# sourceMappingURL=react.force.mobilesync.js.map

--- a/dist/react.force.net.d.ts
+++ b/dist/react.force.net.d.ts
@@ -1,30 +1,193 @@
 import { ExecErrorCallback, ExecSuccessCallback } from "./react.force.common";
 import { HttpMethod } from "./typings";
+/**
+ * Set apiVersion to be used
+ */
 export declare const setApiVersion: (version: string) => void;
+/**
+ * Return apiVersion used
+ */
 export declare const getApiVersion: () => string;
+/**
+ * Send arbitray force.com request
+ */
 export declare const sendRequest: <T>(endPoint: string, path: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback, method?: HttpMethod, payload?: Record<string, unknown> | null, headerParams?: Record<string, unknown> | null, fileParams?: unknown, returnBinary?: boolean, doesNotRequireAuthentication?: boolean) => void;
+/**
+ * Lists summary information about each Salesforce.com version currently
+ * available, including the version, label, and a link to each version's
+ * root.
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const versions: <T>(successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Lists available resources for the client's API version, including
+ * resource name and URI.
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const resources: <T>(successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Lists the available objects and their metadata for your organization's
+ * data.
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const describeGlobal: <T>(successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Describes the individual metadata for the specified object.
+ * @param objtype object type; e.g. "Account"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const metadata: <T>(objtype: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Completely describes the individual metadata at all levels for the
+ * specified object.
+ * @param objtype object type; e.g. "Account"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const describe: <T>(objtype: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Fetches the layout configuration for a particular sobject type and record type id.
+ * @param objtype object type; e.g. "Account"
+ * @param (Optional) recordTypeId Id of the layout's associated record type
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const describeLayout: <T>(objtype: string, recordTypeId: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Creates a new record of the given type.
+ * @param objtype object type; e.g. "Account"
+ * @param fields an object containing initial field names and values for
+ *               the record, e.g. {:Name "salesforce.com", :TickerSymbol
+ *               "CRM"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const create: <T>(objtype: string, fields: Record<string, unknown>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
 type RetrieveOverload = {
     <T>(objtype: string, id: string, fieldlist: string[], successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback): void;
     <T>(objtype: string, id: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback): void;
 };
+/**
+ * Retrieves field values for a record of the given type.
+ * @param objtype object type; e.g. "Account"
+ * @param id the record's object ID
+ * @param [fields=null] list of fields for which
+ *               to return values; e.g. Name,Industry,TickerSymbol
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const retrieve: RetrieveOverload;
+/**
+ * Upsert - creates or updates record of the given type, based on the
+ * given external Id.
+ * @param objtype object type; e.g. "Account"
+ * @param externalIdField external ID field name; e.g. "accountMaster__c"
+ * @param externalId the record's external ID value
+ * @param fields an object containing field names and values for
+ *               the record, e.g. {:Name "salesforce.com", :TickerSymbol
+ *               "CRM"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const upsert: <T>(objtype: string, externalIdField: string, externalId: string, fields: Record<string, unknown>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Updates field values on a record of the given type.
+ * @param objtype object type; e.g. "Account"
+ * @param id the record's object ID
+ * @param fields an object containing initial field names and values for
+ *               the record, e.g. {:Name "salesforce.com", :TickerSymbol
+ *               "CRM"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const update: <T>(objtype: string, id: string, fields: Record<string, unknown>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Deletes a record of the given type. Unfortunately, 'delete' is a
+ * reserved word in JavaScript.
+ * @param objtype object type; e.g. "Account"
+ * @param id the record's object ID
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const del: <T>(objtype: string, id: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Executes the specified SOQL query.
+ * @param soql a string containing the query to execute - e.g. "SELECT Id,
+ *             Name from Account ORDER BY Name LIMIT 20"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const query: <T>(soql: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Queries the next set of records based on pagination.
+ * <p>This should be used if performing a query that retrieves more than can be returned
+ * in accordance with http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_query.htm</p>
+
+ * @param url - the url retrieved from nextRecordsUrl or prevRecordsUrl
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const queryMore: <T>(url: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Executes the specified SOSL search.
+ * @param sosl a string containing the search to execute - e.g. "FIND
+ *             {needle}"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const search: <T>(sosl: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Convenience function to retrieve an attachment
+ * @param id
+ * @param callback function to which response will be passed (attachment is returned as {encodedBody:"base64-encoded-response", contentType:"content-type"})
+ * @param [error=null] function called in case of error
+ */
 export declare const getAttachment: <T>(id: string, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Creates up to 2000 new records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param records array of objects containing field names and values as well as a "attributes" property with the object type e.g. {type: "Account"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const collectionCreate: <T>(allOrNone: boolean, records: Array<Record<string, unknown>>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Updates up to 200 records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param records array of objects containing field names and values as well as a "attributes" property with the object type e.g. {type: "Account"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const collectionUpdate: <T>(allOrNone: boolean, records: Array<Record<string, unknown>>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Upserts up to 200 records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param objectType object type; e.g. "Account"
+ * @param externalIdField  name of ID field in source data
+ * @param records array of objects containing field names and values as well as a "attributes" property with the object type e.g. {type: "Account"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const collectionUpsert: <T>(allOrNone: boolean, objectType: string, externalIdField: string, records: Array<Record<string, unknown>>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Retrieves up to 2000 records in one roundtrip to the server.
+ * @param objectType object type; e.g. "Account"
+ * @param ids the ids of records to retrieve
+ * @param fields list of fields for which to return values; e.g. ["Name", "Industry"]
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const collectionRetrieve: <T>(objectType: string, ids: Array<string>, fields: Array<string>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
+/**
+ * Delete up to 200 records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param ids the ids of records to delete
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 export declare const collectionDelete: <T>(allOrNone: boolean, ids: Array<string>, successCB: ExecSuccessCallback<T>, errorCB: ExecErrorCallback) => void;
 export {};

--- a/dist/react.force.net.js
+++ b/dist/react.force.net.js
@@ -1,21 +1,58 @@
 "use strict";
+/*
+ * Copyright (c) 2015-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.collectionDelete = exports.collectionRetrieve = exports.collectionUpsert = exports.collectionUpdate = exports.collectionCreate = exports.getAttachment = exports.search = exports.queryMore = exports.query = exports.del = exports.update = exports.upsert = exports.retrieve = exports.create = exports.describeLayout = exports.describe = exports.metadata = exports.describeGlobal = exports.resources = exports.versions = exports.sendRequest = exports.getApiVersion = exports.setApiVersion = void 0;
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
-const { SalesforceNetReactBridge, SFNetReactBridge } = react_native_1.NativeModules;
-var apiVersion = 'v63.0';
+// New architecture: TurboModuleRegistry first, fall back to NativeModules.
+const SFNetReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFNetReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFNetReactBridge;
+const SalesforceNetReactBridge = (_b = react_native_1.TurboModuleRegistry.get("SalesforceNetReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.SalesforceNetReactBridge;
+var apiVersion = 'v66.0';
+/**
+ * Set apiVersion to be used
+ */
 const setApiVersion = (version) => {
     apiVersion = version;
 };
 exports.setApiVersion = setApiVersion;
+/**
+ * Return apiVersion used
+ */
 const getApiVersion = () => apiVersion;
 exports.getApiVersion = getApiVersion;
+/**
+ * Send arbitray force.com request
+ */
 const sendRequest = (endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams, returnBinary, doesNotRequireAuthentication) => {
     method = method || "GET";
     payload = payload || {};
     headerParams = headerParams || {};
-    fileParams = fileParams || {};
+    fileParams = fileParams || {}; // File params expected to be of the form: {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}
     returnBinary = !!returnBinary;
     doesNotRequireAuthentication = !!doesNotRequireAuthentication;
     const args = {
@@ -31,23 +68,82 @@ const sendRequest = (endPoint, path, successCB, errorCB, method, payload, header
     (0, react_force_common_1.exec)("SFNetReactBridge", "SalesforceNetReactBridge", SFNetReactBridge, SalesforceNetReactBridge, successCB, errorCB, "sendRequest", args);
 };
 exports.sendRequest = sendRequest;
+/**
+ * Lists summary information about each Salesforce.com version currently
+ * available, including the version, label, and a link to each version's
+ * root.
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const versions = (successCB, errorCB) => (0, exports.sendRequest)("/services/data", "/", successCB, errorCB);
 exports.versions = versions;
+/**
+ * Lists available resources for the client's API version, including
+ * resource name and URI.
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const resources = (successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/`, successCB, errorCB);
 exports.resources = resources;
+/**
+ * Lists the available objects and their metadata for your organization's
+ * data.
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const describeGlobal = (successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/`, successCB, errorCB);
 exports.describeGlobal = describeGlobal;
+/**
+ * Describes the individual metadata for the specified object.
+ * @param objtype object type; e.g. "Account"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const metadata = (objtype, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/`, successCB, errorCB);
 exports.metadata = metadata;
+/**
+ * Completely describes the individual metadata at all levels for the
+ * specified object.
+ * @param objtype object type; e.g. "Account"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const describe = (objtype, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/describe/`, successCB, errorCB);
 exports.describe = describe;
-const describeLayout = (objtype, recordTypeId, successCB, errorCB) => {
+/**
+ * Fetches the layout configuration for a particular sobject type and record type id.
+ * @param objtype object type; e.g. "Account"
+ * @param (Optional) recordTypeId Id of the layout's associated record type
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
+const describeLayout = (objtype, recordTypeId, 
+// todo: add describe typings
+successCB, errorCB) => {
     recordTypeId = recordTypeId ? recordTypeId : "";
     return (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/describe/layouts/${recordTypeId}`, successCB, errorCB);
 };
 exports.describeLayout = describeLayout;
+/**
+ * Creates a new record of the given type.
+ * @param objtype object type; e.g. "Account"
+ * @param fields an object containing initial field names and values for
+ *               the record, e.g. {:Name "salesforce.com", :TickerSymbol
+ *               "CRM"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const create = (objtype, fields, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/`, successCB, errorCB, "POST", fields);
 exports.create = create;
+/**
+ * Retrieves field values for a record of the given type.
+ * @param objtype object type; e.g. "Account"
+ * @param id the record's object ID
+ * @param [fields=null] list of fields for which
+ *               to return values; e.g. Name,Industry,TickerSymbol
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const retrieve = (objtype, id, x, y, z) => {
     let fieldlist;
     let successCB;
@@ -66,14 +162,60 @@ const retrieve = (objtype, id, x, y, z) => {
     return (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/${id}`, successCB, errorCB, "GET", fields);
 };
 exports.retrieve = retrieve;
+/**
+ * Upsert - creates or updates record of the given type, based on the
+ * given external Id.
+ * @param objtype object type; e.g. "Account"
+ * @param externalIdField external ID field name; e.g. "accountMaster__c"
+ * @param externalId the record's external ID value
+ * @param fields an object containing field names and values for
+ *               the record, e.g. {:Name "salesforce.com", :TickerSymbol
+ *               "CRM"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const upsert = (objtype, externalIdField, externalId, fields, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/${externalIdField}/${externalId ? externalId : ""}`, successCB, errorCB, externalId ? "PATCH" : "POST", fields);
 exports.upsert = upsert;
+/**
+ * Updates field values on a record of the given type.
+ * @param objtype object type; e.g. "Account"
+ * @param id the record's object ID
+ * @param fields an object containing initial field names and values for
+ *               the record, e.g. {:Name "salesforce.com", :TickerSymbol
+ *               "CRM"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const update = (objtype, id, fields, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/${id}`, successCB, errorCB, "PATCH", fields);
 exports.update = update;
+/**
+ * Deletes a record of the given type. Unfortunately, 'delete' is a
+ * reserved word in JavaScript.
+ * @param objtype object type; e.g. "Account"
+ * @param id the record's object ID
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const del = (objtype, id, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/${id}`, successCB, errorCB, "DELETE");
 exports.del = del;
+/**
+ * Executes the specified SOQL query.
+ * @param soql a string containing the query to execute - e.g. "SELECT Id,
+ *             Name from Account ORDER BY Name LIMIT 20"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const query = (soql, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/query`, successCB, errorCB, "GET", { q: soql });
 exports.query = query;
+/**
+ * Queries the next set of records based on pagination.
+ * <p>This should be used if performing a query that retrieves more than can be returned
+ * in accordance with http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_query.htm</p>
+
+ * @param url - the url retrieved from nextRecordsUrl or prevRecordsUrl
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const queryMore = (url, successCB, errorCB) => {
     const pathFromUrl = url.match(/https:\/\/[^/]*(.*)/);
     if (pathFromUrl && pathFromUrl.length === 2) {
@@ -84,18 +226,70 @@ const queryMore = (url, successCB, errorCB) => {
     }
 };
 exports.queryMore = queryMore;
+/**
+ * Executes the specified SOSL search.
+ * @param sosl a string containing the search to execute - e.g. "FIND
+ *             {needle}"
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const search = (sosl, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/search`, successCB, errorCB, "GET", { q: sosl });
 exports.search = search;
-const getAttachment = (id, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/Attachment/${id}/Body`, successCB, errorCB, "GET", null, null, null, true);
+/**
+ * Convenience function to retrieve an attachment
+ * @param id
+ * @param callback function to which response will be passed (attachment is returned as {encodedBody:"base64-encoded-response", contentType:"content-type"})
+ * @param [error=null] function called in case of error
+ */
+const getAttachment = (id, 
+// todo: add attachment typings
+successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/Attachment/${id}/Body`, successCB, errorCB, "GET", null, null, null, true /* return binary */);
 exports.getAttachment = getAttachment;
+/**
+ * Creates up to 2000 new records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param records array of objects containing field names and values as well as a "attributes" property with the object type e.g. {type: "Account"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const collectionCreate = (allOrNone, records, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/composite/sobjects`, successCB, errorCB, "POST", { allOrNone: allOrNone, records: records });
 exports.collectionCreate = collectionCreate;
+/**
+ * Updates up to 200 records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param records array of objects containing field names and values as well as a "attributes" property with the object type e.g. {type: "Account"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const collectionUpdate = (allOrNone, records, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/composite/sobjects`, successCB, errorCB, "PATCH", { allOrNone: allOrNone, records: records });
 exports.collectionUpdate = collectionUpdate;
+/**
+ * Upserts up to 200 records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param objectType object type; e.g. "Account"
+ * @param externalIdField  name of ID field in source data
+ * @param records array of objects containing field names and values as well as a "attributes" property with the object type e.g. {type: "Account"}
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const collectionUpsert = (allOrNone, objectType, externalIdField, records, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/composite/sobjects/${objectType}/${externalIdField}`, successCB, errorCB, "PATCH", { allOrNone: allOrNone, records: records });
 exports.collectionUpsert = collectionUpsert;
+/**
+ * Retrieves up to 2000 records in one roundtrip to the server.
+ * @param objectType object type; e.g. "Account"
+ * @param ids the ids of records to retrieve
+ * @param fields list of fields for which to return values; e.g. ["Name", "Industry"]
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const collectionRetrieve = (objectType, ids, fields, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/composite/sobjects/${objectType}`, successCB, errorCB, "POST", { ids: ids, fields: fields });
 exports.collectionRetrieve = collectionRetrieve;
+/**
+ * Delete up to 200 records in one roundtrip to the server.
+ * @param allOrNone indicates whether to roll back the entire request when one record fails
+ * @param ids the ids of records to delete
+ * @param callback function to which response will be passed
+ * @param [error=null] function called in case of error
+ */
 const collectionDelete = (allOrNone, ids, successCB, errorCB) => (0, exports.sendRequest)("/services/data", `/${apiVersion}/composite/sobjects?allOrNone=${allOrNone}&ids=${ids.join(',')}`, successCB, errorCB, "DELETE");
 exports.collectionDelete = collectionDelete;
-//# sourceMappingURL=react.force.net.js.map

--- a/dist/react.force.net.js
+++ b/dist/react.force.net.js
@@ -24,14 +24,17 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.collectionDelete = exports.collectionRetrieve = exports.collectionUpsert = exports.collectionUpdate = exports.collectionCreate = exports.getAttachment = exports.search = exports.queryMore = exports.query = exports.del = exports.update = exports.upsert = exports.retrieve = exports.create = exports.describeLayout = exports.describe = exports.metadata = exports.describeGlobal = exports.resources = exports.versions = exports.sendRequest = exports.getApiVersion = exports.setApiVersion = void 0;
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
 // New architecture: TurboModuleRegistry first, fall back to NativeModules.
-const SFNetReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFNetReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFNetReactBridge;
-const SalesforceNetReactBridge = (_b = react_native_1.TurboModuleRegistry.get("SalesforceNetReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.SalesforceNetReactBridge;
+// Lazy lookup - bridgeless mode doesn't have modules ready at import time.
+const getSFNetReactBridge = () => { var _a; return (_a = react_native_1.TurboModuleRegistry.get("SFNetReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFNetReactBridge; };
+const getSalesforceNetReactBridge = () => {
+    var _a;
+    return (_a = react_native_1.TurboModuleRegistry.get("SalesforceNetReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SalesforceNetReactBridge;
+};
 var apiVersion = 'v66.0';
 /**
  * Set apiVersion to be used
@@ -65,7 +68,7 @@ const sendRequest = (endPoint, path, successCB, errorCB, method, payload, header
         returnBinary,
         doesNotRequireAuthentication,
     };
-    (0, react_force_common_1.exec)("SFNetReactBridge", "SalesforceNetReactBridge", SFNetReactBridge, SalesforceNetReactBridge, successCB, errorCB, "sendRequest", args);
+    (0, react_force_common_1.exec)("SFNetReactBridge", "SalesforceNetReactBridge", getSFNetReactBridge(), getSalesforceNetReactBridge(), successCB, errorCB, "sendRequest", args);
 };
 exports.sendRequest = sendRequest;
 /**

--- a/dist/react.force.oauth.d.ts
+++ b/dist/react.force.oauth.d.ts
@@ -1,5 +1,41 @@
 import { ExecSuccessCallback, ExecErrorCallback } from "./react.force.common";
 import { UserAccount } from "./typings/oauth";
+/**
+ * Initiates the authentication process, with the given app configuration.
+ *   success         - The success callback function to use.
+ *   fail            - The failure/error callback function to use.
+ * Returns a dictionary with:
+ *   accessToken
+ *   refreshToken
+ *   clientId
+ *   userId
+ *   orgId
+ *   loginUrl
+ *   instanceUrl
+ *   userAgent
+ *   community id
+ *   community url
+ */
 export declare const authenticate: (successCB: ExecSuccessCallback<UserAccount>, errorCB: ExecErrorCallback) => void;
+/**
+ * Obtain authentication credentials.
+ *   success - The success callback function to use.
+ *   fail    - The failure/error callback function to use.
+ * Returns a dictionary with:
+ *   accessToken
+ *   refreshToken
+ *   clientId
+ *   userId
+ *   orgId
+ *   loginUrl
+ *   instanceUrl
+ *   userAgent
+ *   community id
+ *   community url
+ */
 export declare const getAuthCredentials: (successCB: ExecSuccessCallback<UserAccount>, errorCB: ExecErrorCallback) => void;
+/**
+ * Logout the current authenticated user. This removes any current valid session token
+ * as well as any OAuth refresh token.
+ */
 export declare const logout: <T>(success: ExecSuccessCallback<T>, fail: ExecErrorCallback) => void;

--- a/dist/react.force.oauth.js
+++ b/dist/react.force.oauth.js
@@ -24,17 +24,18 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.logout = exports.getAuthCredentials = exports.authenticate = void 0;
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
-// New architecture: TurboModuleRegistry returns the module if registered as a
-// TurboModule. Falls back to NativeModules (legacy bridge / interop mode).
-const SFOauthReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFOauthReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFOauthReactBridge;
-const SalesforceOauthReactBridge = (_b = react_native_1.TurboModuleRegistry.get("SalesforceOauthReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.SalesforceOauthReactBridge;
+// Lazy module lookup: modules may not be available at import time in bridgeless mode.
+const getSFOauthReactBridge = () => { var _a; return (_a = react_native_1.TurboModuleRegistry.get("SFOauthReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFOauthReactBridge; };
+const getSalesforceOauthReactBridge = () => {
+    var _a;
+    return (_a = react_native_1.TurboModuleRegistry.get("SalesforceOauthReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SalesforceOauthReactBridge;
+};
 const exec = (successCB, errorCB, methodName, args) => {
-    (0, react_force_common_1.exec)("SFOauthReactBridge", "SalesforceOauthReactBridge", SFOauthReactBridge, SalesforceOauthReactBridge, successCB, errorCB, methodName, args);
+    (0, react_force_common_1.exec)("SFOauthReactBridge", "SalesforceOauthReactBridge", getSFOauthReactBridge(), getSalesforceOauthReactBridge(), successCB, errorCB, methodName, args);
 };
 /**
  * Initiates the authentication process, with the given app configuration.

--- a/dist/react.force.oauth.js
+++ b/dist/react.force.oauth.js
@@ -1,22 +1,87 @@
 "use strict";
+/*
+ * Copyright (c) 2015-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.logout = exports.getAuthCredentials = exports.authenticate = void 0;
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
-const { SalesforceOauthReactBridge, SFOauthReactBridge } = react_native_1.NativeModules;
+// New architecture: TurboModuleRegistry returns the module if registered as a
+// TurboModule. Falls back to NativeModules (legacy bridge / interop mode).
+const SFOauthReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFOauthReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFOauthReactBridge;
+const SalesforceOauthReactBridge = (_b = react_native_1.TurboModuleRegistry.get("SalesforceOauthReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.SalesforceOauthReactBridge;
 const exec = (successCB, errorCB, methodName, args) => {
     (0, react_force_common_1.exec)("SFOauthReactBridge", "SalesforceOauthReactBridge", SFOauthReactBridge, SalesforceOauthReactBridge, successCB, errorCB, methodName, args);
 };
+/**
+ * Initiates the authentication process, with the given app configuration.
+ *   success         - The success callback function to use.
+ *   fail            - The failure/error callback function to use.
+ * Returns a dictionary with:
+ *   accessToken
+ *   refreshToken
+ *   clientId
+ *   userId
+ *   orgId
+ *   loginUrl
+ *   instanceUrl
+ *   userAgent
+ *   community id
+ *   community url
+ */
 const authenticate = (successCB, errorCB) => {
     exec(successCB, errorCB, "authenticate", {});
 };
 exports.authenticate = authenticate;
+/**
+ * Obtain authentication credentials.
+ *   success - The success callback function to use.
+ *   fail    - The failure/error callback function to use.
+ * Returns a dictionary with:
+ *   accessToken
+ *   refreshToken
+ *   clientId
+ *   userId
+ *   orgId
+ *   loginUrl
+ *   instanceUrl
+ *   userAgent
+ *   community id
+ *   community url
+ */
 const getAuthCredentials = (successCB, errorCB) => {
     exec(successCB, errorCB, "getAuthCredentials", {});
 };
 exports.getAuthCredentials = getAuthCredentials;
+/**
+ * Logout the current authenticated user. This removes any current valid session token
+ * as well as any OAuth refresh token.
+ */
 const logout = (success, fail) => {
+    // @ts-ignore
     exec(success, fail, "logoutCurrentUser", {});
 };
 exports.logout = logout;
-//# sourceMappingURL=react.force.oauth.js.map

--- a/dist/react.force.smartstore.d.ts
+++ b/dist/react.force.smartstore.d.ts
@@ -1,15 +1,24 @@
 import { ExecErrorCallback, ExecSuccessCallback } from "./react.force.common";
 import { QuerySpecType, StoreOrder } from "./typings";
+/**
+ * StoreConfig class
+ */
 export declare class StoreConfig {
     storeName?: string;
     isGlobalStore?: boolean;
     constructor(storeName: string, isGlobalStore: boolean);
 }
+/**
+ * SoupIndexSpec class
+ */
 export declare class SoupIndexSpec {
     path: string;
     type: string;
     constructor(path: string, type: string);
 }
+/**
+ * QuerySpec class
+ */
 export declare class QuerySpec {
     queryType: QuerySpecType;
     indexPath?: string;
@@ -24,6 +33,9 @@ export declare class QuerySpec {
     selectPaths?: string[];
     constructor(path?: string);
 }
+/**
+ * StoreCursor class
+ */
 export declare class StoreCursor<T> {
     cursorId?: string;
     pageSize: number;

--- a/dist/react.force.smartstore.js
+++ b/dist/react.force.smartstore.js
@@ -24,16 +24,16 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.removeAllStores = exports.removeAllGlobalStores = exports.removeStore = exports.getAllGlobalStores = exports.getAllStores = exports.closeCursor = exports.moveCursorToPreviousPage = exports.moveCursorToNextPage = exports.moveCursorToPageIndex = exports.removeFromSoup = exports.upsertSoupEntriesWithExternalId = exports.upsertSoupEntries = exports.retrieveSoupEntries = exports.runSmartQuery = exports.querySoup = exports.soupExists = exports.clearSoup = exports.reIndexSoup = exports.alterSoup = exports.getSoupIndexSpecs = exports.removeSoup = exports.registerSoup = exports.getDatabaseSize = exports.buildSmartQuerySpec = exports.buildMatchQuerySpec = exports.buildLikeQuerySpec = exports.buildRangeQuerySpec = exports.buildExactQuerySpec = exports.buildAllQuerySpec = exports.StoreCursor = exports.QuerySpec = exports.SoupIndexSpec = exports.StoreConfig = void 0;
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
 // New architecture: TurboModuleRegistry first, fall back to NativeModules.
-const SFSmartStoreReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFSmartStoreReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFSmartStoreReactBridge;
-const SmartStoreReactBridge = (_b = react_native_1.TurboModuleRegistry.get("SmartStoreReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.SmartStoreReactBridge;
+// Lazy lookup - bridgeless mode doesn't have modules ready at import time.
+const getSFSmartStoreReactBridge = () => { var _a; return (_a = react_native_1.TurboModuleRegistry.get("SFSmartStoreReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFSmartStoreReactBridge; };
+const getSmartStoreReactBridge = () => { var _a; return (_a = react_native_1.TurboModuleRegistry.get("SmartStoreReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SmartStoreReactBridge; };
 const exec = (successCB, errorCB, methodName, args) => {
-    (0, react_force_common_1.exec)("SFSmartStoreReactBridge", "SmartStoreReactBridge", SFSmartStoreReactBridge, SmartStoreReactBridge, successCB, errorCB, methodName, args);
+    (0, react_force_common_1.exec)("SFSmartStoreReactBridge", "SmartStoreReactBridge", getSFSmartStoreReactBridge(), getSmartStoreReactBridge(), successCB, errorCB, methodName, args);
 };
 /**
  * StoreConfig class

--- a/dist/react.force.smartstore.js
+++ b/dist/react.force.smartstore.js
@@ -1,12 +1,43 @@
 "use strict";
+/*
+ * Copyright (c) 2015-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.removeAllStores = exports.removeAllGlobalStores = exports.removeStore = exports.getAllGlobalStores = exports.getAllStores = exports.closeCursor = exports.moveCursorToPreviousPage = exports.moveCursorToNextPage = exports.moveCursorToPageIndex = exports.removeFromSoup = exports.upsertSoupEntriesWithExternalId = exports.upsertSoupEntries = exports.retrieveSoupEntries = exports.runSmartQuery = exports.querySoup = exports.soupExists = exports.clearSoup = exports.reIndexSoup = exports.alterSoup = exports.getSoupIndexSpecs = exports.removeSoup = exports.registerSoup = exports.getDatabaseSize = exports.buildSmartQuerySpec = exports.buildMatchQuerySpec = exports.buildLikeQuerySpec = exports.buildRangeQuerySpec = exports.buildExactQuerySpec = exports.buildAllQuerySpec = exports.StoreCursor = exports.QuerySpec = exports.SoupIndexSpec = exports.StoreConfig = void 0;
 const react_native_1 = require("react-native");
 const react_force_common_1 = require("./react.force.common");
-const { SmartStoreReactBridge, SFSmartStoreReactBridge } = react_native_1.NativeModules;
+// New architecture: TurboModuleRegistry first, fall back to NativeModules.
+const SFSmartStoreReactBridge = (_a = react_native_1.TurboModuleRegistry.get("SFSmartStoreReactBridge")) !== null && _a !== void 0 ? _a : react_native_1.NativeModules.SFSmartStoreReactBridge;
+const SmartStoreReactBridge = (_b = react_native_1.TurboModuleRegistry.get("SmartStoreReactBridge")) !== null && _b !== void 0 ? _b : react_native_1.NativeModules.SmartStoreReactBridge;
 const exec = (successCB, errorCB, methodName, args) => {
     (0, react_force_common_1.exec)("SFSmartStoreReactBridge", "SmartStoreReactBridge", SFSmartStoreReactBridge, SmartStoreReactBridge, successCB, errorCB, methodName, args);
 };
+/**
+ * StoreConfig class
+ */
 class StoreConfig {
     constructor(storeName, isGlobalStore) {
         this.storeName = storeName;
@@ -14,6 +45,9 @@ class StoreConfig {
     }
 }
 exports.StoreConfig = StoreConfig;
+/**
+ * SoupIndexSpec class
+ */
 class SoupIndexSpec {
     constructor(path, type) {
         this.path = path;
@@ -21,50 +55,69 @@ class SoupIndexSpec {
     }
 }
 exports.SoupIndexSpec = SoupIndexSpec;
+/**
+ * QuerySpec class
+ */
 class QuerySpec {
     constructor(path) {
+        // the kind of query, one of: "exact","range", "like" or "smart":
+        // "exact" uses matchKey, "range" uses beginKey and endKey, "like" uses likeKey, "smart" uses smartSql
         this.queryType = "exact";
+        // "ascending" or "descending" : optional
         this.order = "ascending";
+        // the number of entries to copy from native to javascript per each cursor page
         this.pageSize = 10;
         this.indexPath = path;
     }
 }
 exports.QuerySpec = QuerySpec;
+/**
+ * StoreCursor class
+ */
 class StoreCursor {
     constructor() {
+        // the maximum number of entries returned per page
         this.pageSize = 0;
+        // the total number of results
         this.totalEntries = 0;
+        // the total number of pages of results available
         this.totalPages = 0;
+        // the current page index among all the pages available
         this.currentPageIndex = 0;
+        // the list of current page entries, ordered as requested in the querySpec
         this.currentPageOrderedEntries = [];
     }
 }
 exports.StoreCursor = StoreCursor;
+// ====== querySpec factory methods
+// Returns a query spec that will page through all soup entries in order by the given path value
+// Internally it simply does a range query with null begin and end keys
 const buildAllQuerySpec = (path, order, pageSize, selectPaths) => {
     const inst = new QuerySpec(path);
     inst.queryType = "range";
     inst.orderPath = path;
     if (order) {
         inst.order = order;
-    }
+    } // override default only if a value was specified
     if (pageSize) {
         inst.pageSize = pageSize;
-    }
+    } // override default only if a value was specified
     if (selectPaths) {
         inst.selectPaths = selectPaths;
     }
     return inst;
 };
 exports.buildAllQuerySpec = buildAllQuerySpec;
+// Returns a query spec that will page all entries exactly matching the matchKey value for path
 const buildExactQuerySpec = (path, matchKey, pageSize, order, orderPath, selectPaths) => {
     const inst = new QuerySpec(path);
     inst.matchKey = matchKey;
     if (pageSize) {
         inst.pageSize = pageSize;
-    }
+    } // override default only if a value was specified
     if (order) {
         inst.order = order;
-    }
+    } // override default only if a value was specified
     inst.orderPath = orderPath ? orderPath : path;
     if (selectPaths) {
         inst.selectPaths = selectPaths;
@@ -72,6 +125,7 @@ const buildExactQuerySpec = (path, matchKey, pageSize, order, orderPath, selectP
     return inst;
 };
 exports.buildExactQuerySpec = buildExactQuerySpec;
+// Returns a query spec that will page all entries in the range beginKey ...endKey for path
 const buildRangeQuerySpec = (path, beginKey, endKey, order, pageSize, orderPath, selectPaths) => {
     const inst = new QuerySpec(path);
     inst.queryType = "range";
@@ -79,10 +133,10 @@ const buildRangeQuerySpec = (path, beginKey, endKey, order, pageSize, orderPath,
     inst.endKey = endKey;
     if (order) {
         inst.order = order;
-    }
+    } // override default only if a value was specified
     if (pageSize) {
         inst.pageSize = pageSize;
-    }
+    } // override default only if a value was specified
     inst.orderPath = orderPath ? orderPath : path;
     if (selectPaths) {
         inst.selectPaths = selectPaths;
@@ -90,16 +144,17 @@ const buildRangeQuerySpec = (path, beginKey, endKey, order, pageSize, orderPath,
     return inst;
 };
 exports.buildRangeQuerySpec = buildRangeQuerySpec;
+// Returns a query spec that will page all entries matching the given likeKey value for path
 const buildLikeQuerySpec = (path, likeKey, order, pageSize, orderPath, selectPaths) => {
     const inst = new QuerySpec(path);
     inst.queryType = "like";
     inst.likeKey = likeKey;
     if (order) {
         inst.order = order;
-    }
+    } // override default only if a value was specified
     if (pageSize) {
         inst.pageSize = pageSize;
-    }
+    } // override default only if a value was specified
     inst.orderPath = orderPath ? orderPath : path;
     if (selectPaths) {
         inst.selectPaths = selectPaths;
@@ -107,6 +162,8 @@ const buildLikeQuerySpec = (path, likeKey, order, pageSize, orderPath, selectPat
     return inst;
 };
 exports.buildLikeQuerySpec = buildLikeQuerySpec;
+// Returns a query spec that will page all entries matching the given full-text search matchKey value for path
+// Pass null for path to match matchKey across all full-text indexed fields
 const buildMatchQuerySpec = (path, matchKey, order, pageSize, orderPath, selectPaths) => {
     const inst = new QuerySpec(path);
     inst.queryType = "match";
@@ -114,10 +171,10 @@ const buildMatchQuerySpec = (path, matchKey, order, pageSize, orderPath, selectP
     inst.orderPath = orderPath;
     if (order) {
         inst.order = order;
-    }
+    } // override default only if a value was specified
     if (pageSize) {
         inst.pageSize = pageSize;
-    }
+    } // override default only if a value was specified
     inst.orderPath = orderPath ? orderPath : path;
     if (selectPaths) {
         inst.selectPaths = selectPaths;
@@ -125,17 +182,23 @@ const buildMatchQuerySpec = (path, matchKey, order, pageSize, orderPath, selectP
     return inst;
 };
 exports.buildMatchQuerySpec = buildMatchQuerySpec;
+// Returns a query spec that will page all results returned by smartSql
 const buildSmartQuerySpec = (smartSql, pageSize) => {
     const inst = new QuerySpec();
     inst.queryType = "smart";
     inst.smartSql = smartSql;
     if (pageSize) {
         inst.pageSize = pageSize;
-    }
+    } // override default only if a value was specified
     return inst;
 };
 exports.buildSmartQuerySpec = buildSmartQuerySpec;
+// If param is a storeconfig return the same storeconfig
+// If param is a boolean, returns a storeconfig object  {'isGlobalStore': boolean}
+// Otherwise, returns a default storeconfig object
 const checkFirstArg = (arg) => {
+    // Turning arguments into array
+    // If first argument is a store config
     if (typeof arg === "object" && arg.hasOwnProperty("isGlobalStore")) {
         return arg;
     }
@@ -145,6 +208,7 @@ const checkFirstArg = (arg) => {
     }
     return { isGlobalStore };
 };
+// ====== Soup manipulation ======
 const getDatabaseSize = (storeConfig, successCB, errorCB) => {
     storeConfig = checkFirstArg(storeConfig);
     exec(successCB, errorCB, "getDatabaseSize", {
@@ -227,7 +291,8 @@ const querySoup = (storeConfig, soupName, querySpec, successCB, errorCB) => {
     }
     if (querySpec.order != null && querySpec.orderPath == null) {
         querySpec.orderPath = querySpec.indexPath;
-    }
+    } // for backward compatibility with pre-3.3 code
+    // query returns serialized json on iOS starting in 7.0
     const successCBdeserializing = successCB
         ? (result) => successCB(typeof result === "string" ? (0, react_force_common_1.safeJSONparse)(result) : result)
         : successCB;
@@ -244,6 +309,7 @@ const runSmartQuery = (storeConfig, querySpec, successCB, errorCB) => {
     if (querySpec.queryType !== "smart") {
         throw new Error("runSmartQuery can only run smart queries");
     }
+    // query returns serialized json on iOS starting in 7.0
     const successCBdeserializing = successCB
         ? (result) => successCB(typeof result === "string" ? (0, react_force_common_1.safeJSONparse)(result) : result)
         : successCB;
@@ -298,8 +364,10 @@ const removeFromSoup = (storeConfig, soupName, entryIdsOrQuerySpec, successCB, e
     exec(successCB, errorCB, "removeFromSoup", execArgs);
 };
 exports.removeFromSoup = removeFromSoup;
+// ====== Cursor manipulation ======
 const moveCursorToPageIndex = (storeConfig, cursor, newPageIndex, successCB, errorCB) => {
     storeConfig = checkFirstArg(storeConfig);
+    // query returns serialized json on iOS starting in 7.0
     let successCBdeserializing;
     if (successCB) {
         successCBdeserializing = (result) => successCB(typeof result === "string" ? (0, react_force_common_1.safeJSONparse)(result) : result);
@@ -319,7 +387,9 @@ const moveCursorToNextPage = (storeConfig, cursor, successCB, errorCB) => {
     storeConfig = checkFirstArg(storeConfig);
     const newPageIndex = cursor.currentPageIndex + 1;
     if (newPageIndex >= cursor.totalPages) {
-        errorCB(new Error("moveCursorToNextPage called while on last page"));
+        errorCB(
+        // cursor,
+        new Error("moveCursorToNextPage called while on last page"));
     }
     else {
         (0, exports.moveCursorToPageIndex)(storeConfig, cursor, newPageIndex, successCB, errorCB);
@@ -330,7 +400,9 @@ const moveCursorToPreviousPage = (storeConfig, cursor, successCB, errorCB) => {
     storeConfig = checkFirstArg(storeConfig);
     const newPageIndex = cursor.currentPageIndex - 1;
     if (newPageIndex < 0) {
-        errorCB(new Error("moveCursorToPreviousPage called while on first page"));
+        errorCB(
+        // cursor,
+        new Error("moveCursorToPreviousPage called while on first page"));
     }
     else {
         (0, exports.moveCursorToPageIndex)(storeConfig, cursor, newPageIndex, successCB, errorCB);
@@ -346,6 +418,7 @@ const closeCursor = (storeConfig, cursor, successCB, errorCB) => {
     });
 };
 exports.closeCursor = closeCursor;
+// ====== Store Operations ======
 const getAllStores = (successCB, errorCB) => {
     exec(successCB, errorCB, "getAllStores", {});
 };
@@ -370,4 +443,3 @@ const removeAllStores = (successCB, errorCB) => {
     exec(successCB, errorCB, "removeAllStores", {});
 };
 exports.removeAllStores = removeAllStores;
-//# sourceMappingURL=react.force.smartstore.js.map

--- a/dist/react.force.test.js
+++ b/dist/react.force.test.js
@@ -1,4 +1,29 @@
 "use strict";
+/*
+ * Copyright (c) 2018-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -53,12 +78,13 @@ const registerTest = (test) => {
 };
 exports.registerTest = registerTest;
 const testDone = () => {
+    // iOS
     if (TestModule) {
         TestModule.markTestCompleted();
     }
+    // Android
     else if (SalesforceTestBridge) {
         SalesforceTestBridge.markTestCompleted();
     }
 };
 exports.testDone = testDone;
-//# sourceMappingURL=react.force.test.js.map

--- a/dist/react.force.util.js
+++ b/dist/react.force.util.js
@@ -4,7 +4,33 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.timeoutPromiser = exports.promiserNoRejection = exports.promiser = void 0;
+/*
+ * Copyright (c) 2018-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 const react_force_log_1 = require("./react.force.log");
+// @ts-ignore
 const react_native_timer_1 = __importDefault(require("react-native-timer"));
 const rejectionTracking = require("promise/setimmediate/rejection-tracking");
 const enableErrorOnUnhandledPromiseRejection = () => {
@@ -52,6 +78,7 @@ const promiserNoRejection = (func) => {
     const retfn = function () {
         const args = Array.prototype.slice.call(arguments);
         return new Promise(function (resolve) {
+            // then() will be called whether it succeeded or failed
             const callback = () => {
                 try {
                     resolve.apply(null, arguments);
@@ -78,4 +105,3 @@ const timeoutPromiser = (millis) => {
     });
 };
 exports.timeoutPromiser = timeoutPromiser;
-//# sourceMappingURL=react.force.util.js.map

--- a/dist/typings/index.js
+++ b/dist/typings/index.js
@@ -1,3 +1,2 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-//# sourceMappingURL=index.js.map

--- a/dist/typings/mobilesync.js
+++ b/dist/typings/mobilesync.js
@@ -1,3 +1,2 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-//# sourceMappingURL=mobilesync.js.map

--- a/dist/typings/oauth.js
+++ b/dist/typings/oauth.js
@@ -1,3 +1,2 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-//# sourceMappingURL=oauth.js.map

--- a/dist/typings/smartstore.js
+++ b/dist/typings/smartstore.js
@@ -1,3 +1,2 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-//# sourceMappingURL=smartstore.js.map

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -418,19 +418,23 @@ While the JavaScript API is identical on both platforms, there are implementatio
 | smartstore | `SFSmartStoreReactBridge` | `SmartStoreReactBridge` |
 | mobilesync | `SFMobileSyncReactBridge` | `MobileSyncReactBridge` |
 
-### Callback Signature
+### Callback Signature (Unified)
 
-**iOS**: Single callback with `(error, result)` tuple
+Both platforms now use the same single-callback pattern with `(error, result)`:
+
+**iOS** (Objective-C):
 ```objective-c
 callback(@[[NSNull null], result]); // success
 callback(@[error, [NSNull null]]);  // error
 ```
 
-**Android**: Separate success and error callbacks
-```java
-successCallback.invoke(result.toString());  // success
-errorCallback.invoke(error.getMessage());   // error
+**Android** (Kotlin):
+```kotlin
+ReactBridgeHelper.invokeSuccess(callback, result)  // invokes callback(null, resultString)
+ReactBridgeHelper.invokeError(callback, error)     // invokes callback(errorMessage)
 ```
+
+The JavaScript bridge function handles both platforms with one unified code path.
 
 ### Data Serialization
 

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.1.0",
     "react-native": "0.81.5",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-migration"
   },
   "devDependencies": {
     "chai": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "tsconfig.json",
     "src/**/*",
     "ios/SalesforceReact/**/*",
-    "SalesforceReact.podspec"
+    "SalesforceReact.podspec",
+    "android/**/*",
+    "react-native.config.js"
   ],
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageImportPath: 'import com.salesforce.androidsdk.reactnative.app.SalesforceReactPackage;',
+        packageInstance: 'new SalesforceReactPackage()',
+      },
+      ios: null,
+    },
+  },
+};

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -4,6 +4,7 @@ module.exports = {
       android: {
         packageImportPath: 'import com.salesforce.androidsdk.reactnative.app.SalesforceReactPackage;',
         packageInstance: 'new SalesforceReactPackage()',
+        sourceDir: './android',
       },
       ios: null,
     },

--- a/src/react.force.common.ts
+++ b/src/react.force.common.ts
@@ -28,21 +28,6 @@ import { sdkConsole } from "./react.force.log";
 import { ModuleAndroidName, ModuleIOSName } from "./typings";
 
 /**
- * Represents an iOS Module callback
- */
-export type iOSModuleCallback<T> = (err: Error, result: T) => void;
-
-/**
- * Represents an Android Module success callback
- */
-export type AndroidSuccessCallback = (result: string) => void;
-
-/**
- * Represents an Android Module error callback
- */
-export type AndroidErrorCallback = (err: string) => void;
-
-/**
  * Represents an exec() success callback
  */
 export type ExecSuccessCallback<T> = (result: T) => void;
@@ -53,87 +38,53 @@ export type ExecSuccessCallback<T> = (result: T) => void;
 export type ExecErrorCallback = (err: Error) => void;
 
 /**
- * Represents a Mobile SDK iOS Module
- *
- * @interface ModuleIOS
- * @template T
+ * Represents a native module with unified single-callback pattern.
+ * Both iOS and Android now use: module.method(args, (error, result) => {...})
  */
-interface ModuleIOS<T> {
-  [key: string]: (args: unknown, callback: iOSModuleCallback<T>) => void;
+interface NativeModule {
+  [key: string]: (args: unknown, callback: (error: any, result: any) => void) => void;
 }
 
 /**
- * Represents a Mobile SDK Android Module
- *
- * @interface ModuleAndroid
- */
-interface ModuleAndroid {
-  [key: string]: (args: unknown, successCB: AndroidSuccessCallback, errorCB: AndroidErrorCallback) => void;
-}
-
-/**
- * Executes an action using the React Native Mobile SDK Bridge
- *
- * @template T
- * @param {ModuleIOSName} moduleIOSName
- * @param {ModuleAndroidName} moduleAndroidName
- * @param {ModuleIOS<T>} moduleIOS
- * @param {ModuleAndroid<T>} moduleAndroid
- * @param {ExecSuccessCallback<T> | null} successCB
- * @param {ExecErrorCallback | null} errorCB
- * @param {string} methodName
- * @param {Record<string, unknown>} args
+ * Executes an action using the React Native Mobile SDK Bridge.
+ * Both iOS and Android use a unified single-callback pattern:
+ * callback(error, result) where error is null on success.
  */
 export const exec = <T>(
   moduleIOSName: ModuleIOSName,
   moduleAndroidName: ModuleAndroidName,
-  moduleIOS: ModuleIOS<T>,
-  moduleAndroid: ModuleAndroid,
+  moduleIOS: NativeModule,
+  moduleAndroid: NativeModule,
   successCB: ExecSuccessCallback<T> | null,
   errorCB: ExecErrorCallback | null,
   methodName: string,
   args: Record<string, unknown>,
 ): void => {
-  if (moduleIOS) {
-    const func = `${moduleIOSName}.${methodName}`;
-    sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
+  const module = moduleIOS ?? moduleAndroid;
+  const moduleName = moduleIOS ? moduleIOSName : moduleAndroidName;
 
-    moduleIOS[methodName](args, (error: Error, result) => {
-      if (error) {
-        sdkConsole.error(`${func} failed: ${JSON.stringify(error)}`);
-        if (errorCB) errorCB(error);
-      } else {
-        sdkConsole.debug(`${func} succeeded`);
-        if (successCB) successCB(result);
-      }
-    });
+  if (!module) {
+    sdkConsole.error(`No native module found for ${moduleIOSName}/${moduleAndroidName}`);
+    if (errorCB) errorCB(new Error("Native module not available"));
+    return;
   }
-  // android
-  else if (moduleAndroid) {
-    const func = `${moduleAndroidName}.${methodName}`;
-    sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
-    moduleAndroid[methodName](
-      args,
-      (result) => {
-        sdkConsole.debug(`${func} succeeded`);
-        if (successCB) {
-          successCB(safeJSONparse(result));
-        }
-      },
-      (error) => {
-        sdkConsole.error(`${func} failed: ${JSON.stringify(error)}`);
-        if (errorCB) errorCB(safeJSONparse(error));
-      },
-    );
-  }
+
+  const func = `${moduleName}.${methodName}`;
+  sdkConsole.debug(`${func} called: ${JSON.stringify(args)}`);
+
+  module[methodName](args, (error: any, result: any) => {
+    if (error) {
+      sdkConsole.error(`${func} failed: ${JSON.stringify(error)}`);
+      if (errorCB) errorCB(typeof error === "string" ? safeJSONparse(error) : error);
+    } else {
+      sdkConsole.debug(`${func} succeeded`);
+      if (successCB) successCB(typeof result === "string" ? safeJSONparse(result) : result);
+    }
+  });
 };
 
 /**
- * Returns a parsed JSON Android result
- *
- * @template T
- * @param {string} str
- * @returns {T}
+ * Parses a JSON string safely, returning the original value if parsing fails.
  */
 export const safeJSONparse = <T>(str: string): T => {
   try {

--- a/src/react.force.mobilesync.ts
+++ b/src/react.force.mobilesync.ts
@@ -29,9 +29,10 @@ import { StoreConfig } from "./react.force.smartstore";
 import { SyncDownTarget, SyncEvent, SyncMethod, SyncOptions, SyncStatus, SyncUpTarget } from "./typings/mobilesync";
 
 // New architecture: TurboModuleRegistry first, fall back to NativeModules.
-const SFMobileSyncReactBridge =
+// Lazy lookup - bridgeless mode doesn't have modules ready at import time.
+const getSFMobileSyncReactBridge = () =>
   TurboModuleRegistry.get<any>("SFMobileSyncReactBridge") ?? NativeModules.SFMobileSyncReactBridge;
-const MobileSyncReactBridge =
+const getMobileSyncReactBridge = () =>
   TurboModuleRegistry.get<any>("MobileSyncReactBridge") ?? NativeModules.MobileSyncReactBridge;
 
 // If param is a storeconfig return the same storeconfig
@@ -60,8 +61,8 @@ const exec = <T>(
   forceExec(
     "SFMobileSyncReactBridge",
     "MobileSyncReactBridge",
-    SFMobileSyncReactBridge,
-    MobileSyncReactBridge,
+    getSFMobileSyncReactBridge(),
+    getMobileSyncReactBridge(),
     successCB,
     errorCB,
     methodName,

--- a/src/react.force.net.ts
+++ b/src/react.force.net.ts
@@ -29,9 +29,10 @@ import { exec as forceExec, ExecErrorCallback, ExecSuccessCallback } from "./rea
 import { HttpMethod } from "./typings";
 
 // New architecture: TurboModuleRegistry first, fall back to NativeModules.
-const SFNetReactBridge =
+// Lazy lookup - bridgeless mode doesn't have modules ready at import time.
+const getSFNetReactBridge = () =>
   TurboModuleRegistry.get<any>("SFNetReactBridge") ?? NativeModules.SFNetReactBridge;
-const SalesforceNetReactBridge =
+const getSalesforceNetReactBridge = () =>
   TurboModuleRegistry.get<any>("SalesforceNetReactBridge") ??
   NativeModules.SalesforceNetReactBridge;
 
@@ -83,8 +84,8 @@ export const sendRequest = <T>(
   forceExec(
     "SFNetReactBridge",
     "SalesforceNetReactBridge",
-    SFNetReactBridge,
-    SalesforceNetReactBridge,
+    getSFNetReactBridge(),
+    getSalesforceNetReactBridge(),
     successCB,
     errorCB,
     "sendRequest",

--- a/src/react.force.oauth.ts
+++ b/src/react.force.oauth.ts
@@ -28,11 +28,10 @@ import { NativeModules, TurboModuleRegistry } from "react-native";
 import { exec as forceExec, ExecSuccessCallback, ExecErrorCallback } from "./react.force.common";
 import { OAuthMethod, UserAccount } from "./typings/oauth";
 
-// New architecture: TurboModuleRegistry returns the module if registered as a
-// TurboModule. Falls back to NativeModules (legacy bridge / interop mode).
-const SFOauthReactBridge =
+// Lazy module lookup: modules may not be available at import time in bridgeless mode.
+const getSFOauthReactBridge = () =>
   TurboModuleRegistry.get<any>("SFOauthReactBridge") ?? NativeModules.SFOauthReactBridge;
-const SalesforceOauthReactBridge =
+const getSalesforceOauthReactBridge = () =>
   TurboModuleRegistry.get<any>("SalesforceOauthReactBridge") ??
   NativeModules.SalesforceOauthReactBridge;
 
@@ -45,8 +44,8 @@ const exec = <T>(
   forceExec(
     "SFOauthReactBridge",
     "SalesforceOauthReactBridge",
-    SFOauthReactBridge,
-    SalesforceOauthReactBridge,
+    getSFOauthReactBridge(),
+    getSalesforceOauthReactBridge(),
     successCB,
     errorCB,
     methodName,

--- a/src/react.force.smartstore.ts
+++ b/src/react.force.smartstore.ts
@@ -30,9 +30,10 @@ import { QuerySpecType, StoreOrder } from "./typings";
 import { SmartStoreMethod } from "./typings/smartstore";
 
 // New architecture: TurboModuleRegistry first, fall back to NativeModules.
-const SFSmartStoreReactBridge =
+// Lazy lookup - bridgeless mode doesn't have modules ready at import time.
+const getSFSmartStoreReactBridge = () =>
   TurboModuleRegistry.get<any>("SFSmartStoreReactBridge") ?? NativeModules.SFSmartStoreReactBridge;
-const SmartStoreReactBridge =
+const getSmartStoreReactBridge = () =>
   TurboModuleRegistry.get<any>("SmartStoreReactBridge") ?? NativeModules.SmartStoreReactBridge;
 
 const exec = <T>(
@@ -44,8 +45,8 @@ const exec = <T>(
   forceExec(
     "SFSmartStoreReactBridge",
     "SmartStoreReactBridge",
-    SFSmartStoreReactBridge,
-    SmartStoreReactBridge,
+    getSFSmartStoreReactBridge(),
+    getSmartStoreReactBridge(),
     successCB,
     errorCB,
     methodName,


### PR DESCRIPTION
## Summary

- Unify the JS-side callback pattern: remove iOS/Android platform branching in `react.force.common.ts`
- Both platforms now use a single callback with `(error, result)` convention
- Point `iosTests/package.json` at `wmathurin#rn-migration` for CI

## Changes

- `src/react.force.common.ts` — single code path for both platforms
- `docs/ARCHITECTURE.md` — updated callback documentation
- `iosTests/package.json` — points at `wmathurin#rn-migration`

## Testing

- TypeScript compiles cleanly
- iOS tests pass (35/35) with unified callback code
- All 4 RN templates build on iOS

## Before merging

- [ ] Revert `iosTests/package.json` to point at `forcedotcom#dev`