### PR TITLE
Update nightly schedule to Mon/Wed/Fri at 9:30 PM PT and fix security issues

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,9 +2,12 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: "0 5 * * 0"  # cron is UTC, this translates to 10 PM PST Sunday.
+    - cron: "30 5 * * 2,4,6"  # cron is UTC; 9:30 PM PT Mon/Wed/Fri.
   # This lets us trigger the workflow from a browser.
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   ios-nightly:
@@ -21,8 +24,12 @@ jobs:
     with:
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-    secrets: inherit
+    secrets:
+      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   android-nightly:
     uses: ./.github/workflows/reusable-android-workflow.yaml
-    secrets: inherit
+    secrets:
+      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   ios-nightly:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +32,8 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   android-nightly:
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-android-workflow.yaml
     secrets:
       TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,13 @@
 name: Pull Request
 
 on:
-  pull_request_target:
+  # pull_request_target is required for fork PRs to receive secrets.
+  # Mitigated by per-job Member Check (Validate Write Permission).
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     branches: [dev, master]
+
+permissions:
+  contents: read
 
 jobs:
   permission-check:
@@ -11,21 +16,25 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:
       - name: Check Write Permission
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
         id: check_permissions
         with:
           route: GET /repos/${{ github.repository }}/collaborators/${{ github.triggering_actor }}/permission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Debug Permission Response
+        env:
+          PERMISSION_DATA: ${{ steps.check_permissions.outputs.data }}
         run: |
-          echo "Permission raw response: ${{ steps.check_permissions.outputs.data }}"
+          echo "Permission raw response: ${PERMISSION_DATA}"
       - name: Validate Write Permission
+        env:
+          PERMISSION: ${{ fromJson(steps.check_permissions.outputs.data).permission }}
+          ACTOR: ${{ github.triggering_actor }}
         run: |
-          permission=$(echo "${{ fromJson(steps.check_permissions.outputs.data).permission }}")
-          echo "User ${{ github.triggering_actor }} has permission: $permission"
-          if [[ "$permission" != "write" && "$permission" != "admin" ]]; then
-            echo "User ${{ github.triggering_actor }} does not have sufficient permission (write or admin) to proceed. Someone from the team needs to rerun this workflow AFTER it has been deemed safe."
+          echo "User ${ACTOR} has permission: ${PERMISSION}"
+          if [[ "${PERMISSION}" != "write" && "${PERMISSION}" != "admin" ]]; then
+            echo "User ${ACTOR} does not have sufficient permission (write or admin) to proceed. Someone from the team needs to rerun this workflow AFTER it has been deemed safe."
             exit 1
           fi
 
@@ -44,11 +53,15 @@ jobs:
       is_pr: true
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-    secrets: inherit
+    secrets:
+      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   android-pr:
     needs: [permission-check]
     uses: ./.github/workflows/reusable-android-workflow.yaml
     with:
       is_pr: true
-    secrets: inherit
+    secrets:
+      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,6 +39,9 @@ jobs:
           fi
 
   ios-pr:
+    permissions:
+      contents: read
+      pull-requests: write
     needs: [permission-check]
     strategy:
       matrix:
@@ -58,6 +61,8 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   android-pr:
+    permissions:
+      contents: read
     needs: [permission-check]
     uses: ./.github/workflows/reusable-android-workflow.yaml
     with:

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -4,22 +4,32 @@ on:
       is_pr:
         type: boolean
         default: false
+    secrets:
+      TEST_CREDENTIALS:
+        required: true
+      GCLOUD_SERVICE_KEY:
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
   test-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           fetch-depth: 100
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 20
       - name: Install Dependencies
@@ -30,25 +40,36 @@ jobs:
           cd androidTests
           ./prepareandroid.js
           ./create_test_credentials_from_env.js
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.14.3"
           add-job-summary: on-failure
       - name: Build for Testing
+        id: build
         run: |
+          mkdir -p build_logs
+          set -o pipefail
           cd androidTests/android
-          ./gradlew :app:assembleDebug :app:assembleAndroidTest
-      - uses: 'google-github-actions/auth@v2'
+          ./gradlew :app:assembleDebug :app:assembleAndroidTest 2>&1 | tee "../../build_logs/build.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: build-logs-rn-android
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
+      - uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed'  # v2.1.13
         if: success() || failure()
         with:
           credentials_json: '${{ secrets.GCLOUD_SERVICE_KEY }}'
-      - uses: 'google-github-actions/setup-gcloud@v2'
+      - uses: 'google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f'  # v2.2.1
         if: success() || failure()
       - name: Run Tests on Firebase Test Lab
         if: success() || failure()
@@ -71,7 +92,7 @@ jobs:
           mkdir -p firebase_results
           gsutil -m cp -r "${BUCKET_PATH}/*/test_result_*.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()
         with:
           check_name: Android Test Results
@@ -79,7 +100,7 @@ jobs:
           fail_on_failure: true
           report_paths: 'firebase_results/**.xml'
       - name: Archive Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: success() || failure()
         with:
           name: test-results-android

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -16,18 +16,29 @@ on:
       is_pr:
         type: boolean
         default: false
+    secrets:
+      TEST_CREDENTIALS:
+        required: true
+      CODECOV_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   test-ios:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         env:
@@ -38,7 +49,7 @@ jobs:
           cd iosTests
           ./prepareios.js
           ./create_test_credentials_from_env.js
-      - uses: mxcl/xcodebuild@v3
+      - uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5  # v3.6.0
         id: xcodebuild
         with:
           xcode: ${{ inputs.xcode }}
@@ -48,13 +59,24 @@ jobs:
           scheme: "SalesforceReactTestApp"
           code-coverage: true
           verbosity: xcbeautify
+      - name: Archive xcodebuild logs on build failure
+        if: failure() && steps.xcodebuild.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: xcodebuild-logs-rn-ios${{ inputs.ios }}
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/Logs/Build/*.xcactivitylog
+          if-no-files-found: ignore
+          retention-days: 14
       - name: Parse test results
         if: success() || failure()
+        env:
+          IOS: ${{ inputs.ios }}
         run: |
           brew install xcresultparser
-          xcresultparser -o junit test.xcresult > test-results-ios${{ inputs.ios }}.xml
+          xcresultparser -o junit test.xcresult > "test-results-ios${IOS}.xml"
       - name: Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()
         with:
           check_name: iOS ${{ inputs.ios }} Test Results
@@ -66,13 +88,13 @@ jobs:
           comment: true
           job_summary: ${{ steps.xcodebuild.outcome == 'failure' }}
           report_paths: 'test-results-ios${{ inputs.ios }}.xml'
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: success() || failure()
       - name: Upload test results artifact
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: test-results-ios${{ inputs.ios }}
           path: test-results-ios${{ inputs.ios }}.xml


### PR DESCRIPTION
## Summary

Implements [W-22712082 — Cleanup CI for all Repos](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b3viMYAQ/view).

**Schedule change**: Nightly tests now run **Mon/Wed/Fri at 9:30 PM PT** (`30 5 * * 2,4,6` UTC), up from Sun-only. Run cost is low (~13m) and the previous weekly cadence was missing regressions for up to 7 days during high-activity sprints (e.g., May 2026 had 57 commits). Alternates with the iOS-Hybrid nightly's Tue/Thu 9:30 PM slot.

**Security hardening**: All workflows updated to follow the [GitHub Actions injection-prevention best practices](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/):

- **All third-party actions SHA-pinned** with the resolved tag in a comment.
- **Top-level `permissions:` block** added to every workflow: `contents: read` baseline, `pull-requests: write` for the iOS reusable workflow (uses `mikepenz/action-junit-report` with `comment: true`).
- **`secrets: inherit` replaced with explicit secret pass-through**; iOS reusable workflow declares `TEST_CREDENTIALS`/`CODECOV_TOKEN`, Android reusable declares `TEST_CREDENTIALS`/`GCLOUD_SERVICE_KEY`.
- **All `${{ ... }}` shell interpolation** in `run:` blocks refactored to `env:` variables with quoted shell expansions.
- **`pull_request_target`** retained with `# zizmor: ignore[dangerous-triggers]` and inline comment documenting the Member Check mitigation.
- **`actions/checkout` steps** set `with: persist-credentials: false`.
- **Build logs archived on failure** for diagnostic purposes.
- **Job-level `permissions:` on reusable-workflow callers** in `nightly.yaml` and `pr.yaml`, matching the permissions declared in the iOS reusable (`pull-requests: write` for action-junit-report PR comments).

After this change, `zizmor --offline` reports 0 High-confidence findings across all four CI workflows.

## Test plan

- [x] Verified locally with `python3 yaml.safe_load`, `actionlint -shellcheck=`, `zizmor --offline`. All clean.
- [x] CI verification: opened test PR on personal fork (`brandonpage/SalesforceMobileSDK-ReactNative#1`) targeting the same `cleanup-ci-w22712082` branch as this PR. The test PR triggers the new workflows against a real source change in `react.force.log.ts`. **No regressions observed** — see linked PR for run details.
- [ ] Reviewer to confirm the `permissions:` blocks match the team's expected privilege levels for each workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
