### PR TITLE
Simplify test infrastructure and fix versions

### DIFF
--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -38,8 +38,8 @@ jobs:
         run: |
           npm install -g typescript
           cd androidTests
-          ./prepareandroid.js
           ./create_test_credentials_from_env.js
+          ./prepareandroid.js
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -47,8 +47,8 @@ jobs:
           brew install gnu-sed
           npm install -g typescript
           cd iosTests
-          ./prepareios.js
           ./create_test_credentials_from_env.js
+          ./prepareios.js
       - uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5  # v3.6.0
         id: xcodebuild
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,19 +11,23 @@ iosTests/test_credentials.json
 iosTests/ios/test_credentials.json
 androidTests/test_credentials.json
 
-# Android test generated assets and credentials
+# iOS test generated files
+iosTests/ios/index.ios.bundle
+iosTests/mobile_sdk/
+
+# Android test generated files
 androidTests/android/app/src/main/assets/index.android.bundle
 androidTests/android/app/src/main/assets/test_credentials.json
 androidTests/android/app/src/main/assets/drawable-mdpi/
 androidTests/mobile_sdk/
 
-
 # Gradle build output
 androidTests/android/.gradle/
 androidTests/android/app/build/
-
+androidTests/android/build/
 androidTests/android/.kotlin/
 androidTests/android/app/.cxx/
+androidTests/android/local.properties
 
 # Android library build output
 android/.gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ yarn.lock
 .DS_Store
 
 # Test credentials (contains real Salesforce org credentials)
-shared/test/test_credentials.json
+iosTests/test_credentials.json
+iosTests/ios/test_credentials.json
+androidTests/test_credentials.json
 
 # Android test generated assets and credentials
 androidTests/android/app/src/main/assets/index.android.bundle

--- a/androidTests/android/app/build.gradle.kts
+++ b/androidTests/android/app/build.gradle.kts
@@ -54,6 +54,16 @@ kotlin {
     jvmToolchain(17)
 }
 
+// Copy test_credentials.json from androidTests/ root into assets before each build
+tasks.register<Copy>("copyTestCredentials") {
+    from("${rootProject.projectDir}/../test_credentials.json")
+    into("src/main/assets")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+tasks.matching { it.name.startsWith("merge") && it.name.contains("Assets") }.configureEach {
+    dependsOn("copyTestCredentials")
+}
+
 dependencies {
     // SalesforceReact is provided by react-native-force autolinking
     implementation("com.facebook.react:react-android:0.81.5")

--- a/androidTests/android/app/build.gradle.kts
+++ b/androidTests/android/app/build.gradle.kts
@@ -65,10 +65,8 @@ tasks.matching { it.name.startsWith("merge") && it.name.contains("Assets") }.con
 }
 
 dependencies {
-    // SalesforceReact is provided by react-native-force autolinking
-    implementation("com.facebook.react:react-android:0.81.5")
-    implementation("com.facebook.react:react-android:0.81.5")
-    implementation("com.facebook.react:hermes-android:0.81.5")
+    implementation("com.facebook.react:react-android:0.82.1")
+    implementation("com.facebook.react:hermes-android:0.82.1")
 
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")

--- a/androidTests/create_test_credentials_from_env.js
+++ b/androidTests/create_test_credentials_from_env.js
@@ -1,16 +1,10 @@
 #!/usr/bin/env node
 
 var fs = require('fs');
-var path = require('path');
-
-var credentialsFile = path.join('android', 'app', 'src', 'main', 'assets', 'test_credentials.json');
 
 if (process.env.TEST_CREDENTIALS) {
     console.log('Writing test credentials from TEST_CREDENTIALS env var');
-    fs.writeFileSync(credentialsFile, process.env.TEST_CREDENTIALS, 'utf8');
+    fs.writeFileSync('test_credentials.json', process.env.TEST_CREDENTIALS, 'utf8');
 } else {
-    console.log('TEST_CREDENTIALS env var not set - using placeholder');
-    if (!fs.existsSync(credentialsFile)) {
-        fs.writeFileSync(credentialsFile, '{}', 'utf8');
-    }
+    console.log('TEST_CREDENTIALS env var not set - skipping');
 }

--- a/androidTests/package.json
+++ b/androidTests/package.json
@@ -14,7 +14,7 @@
     "jsc-android": "^250231.0.0",
     "react": "19.1.1",
     "react-native": "0.82.1",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
+    "react-native-force": "file:.."
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/androidTests/prepareandroid.js
+++ b/androidTests/prepareandroid.js
@@ -22,6 +22,8 @@ var destCredentials = path.join(assetsDir, 'test_credentials.json');
 if (fs.existsSync(srcCredentials)) {
     fs.copyFileSync(srcCredentials, destCredentials);
 } else {
+    console.warn('WARNING: test_credentials.json not found. Tests will fail at runtime.');
+    console.warn('         Place your test_credentials.json in androidTests/ and re-run.');
     fs.writeFileSync(destCredentials, '{}', 'utf8');
 }
 

--- a/androidTests/prepareandroid.js
+++ b/androidTests/prepareandroid.js
@@ -12,14 +12,17 @@ execSync('yarn install', {stdio:[0,1,2]});
 console.log('=== Installing sdk dependencies');
 execSync('node ./updatesdk.js', {stdio: [0,1,2]});
 
-console.log('=== Creating test_credentials.json');
+console.log('=== Copying test_credentials.json to assets');
 var assetsDir = path.join('android', 'app', 'src', 'main', 'assets');
 if (!fs.existsSync(assetsDir)) {
     fs.mkdirSync(assetsDir, {recursive: true});
 }
-var credentialsFile = path.join(assetsDir, 'test_credentials.json');
-if (!fs.existsSync(credentialsFile)) {
-    fs.writeFileSync(credentialsFile, '{}', 'utf8');
+var srcCredentials = 'test_credentials.json';
+var destCredentials = path.join(assetsDir, 'test_credentials.json');
+if (fs.existsSync(srcCredentials)) {
+    fs.copyFileSync(srcCredentials, destCredentials);
+} else {
+    fs.writeFileSync(destCredentials, '{}', 'utf8');
 }
 
 console.log('=== Creating index.android.bundle');

--- a/iosTests/create_test_credentials_from_env.js
+++ b/iosTests/create_test_credentials_from_env.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
-require("fs").writeFile("ios/test_credentials.json",
-                        `${process.env.TEST_CREDENTIALS}`,
-                        function (err) {
-                            if (err) throw err;
-                        });
+var fs = require('fs');
+
+if (process.env.TEST_CREDENTIALS) {
+    console.log('Writing test credentials from TEST_CREDENTIALS env var');
+    fs.writeFileSync('test_credentials.json', process.env.TEST_CREDENTIALS, 'utf8');
+    fs.writeFileSync('ios/test_credentials.json', process.env.TEST_CREDENTIALS, 'utf8');
+} else {
+    console.log('TEST_CREDENTIALS env var not set - skipping');
+}

--- a/iosTests/ios/Podfile
+++ b/iosTests/ios/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 # Resolve react_native_pods.rb with node to allow for hoisting
 require Pod::Executable.execute_command('node', ['-p',
   'require.resolve(

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.1.1",
     "react-native": "0.82.1",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
+    "react-native-force": "file:.."
   },
   "devDependencies": {
     "chai": "4.4.1",

--- a/iosTests/prepareios.js
+++ b/iosTests/prepareios.js
@@ -25,6 +25,8 @@ var fs = require('fs');
 if (fs.existsSync('test_credentials.json')) {
     fs.copyFileSync('test_credentials.json', 'ios/test_credentials.json');
 } else if (!fs.existsSync('ios/test_credentials.json')) {
+    console.warn('WARNING: test_credentials.json not found. Tests will fail at runtime.');
+    console.warn('         Place your test_credentials.json in iosTests/ and re-run.');
     fs.writeFileSync('ios/test_credentials.json', '{}', 'utf8');
 }
 

--- a/iosTests/prepareios.js
+++ b/iosTests/prepareios.js
@@ -20,8 +20,13 @@ const nodePath = execSync('command -v node', { encoding: 'utf-8' }).trim();
 execSync(`echo export NODE_BINARY=${nodePath} > .xcode.env`, {stdio:[0,1,2], cwd:'ios'});
 execSync('pod update', {stdio:[0,1,2], cwd:'ios'});
 
-console.log('=== Creating test_credentials.json');
-execSync('touch test_credentials.json', {stdio:[0,1,2]});
+console.log('=== Copying test_credentials.json');
+var fs = require('fs');
+if (fs.existsSync('test_credentials.json')) {
+    fs.copyFileSync('test_credentials.json', 'ios/test_credentials.json');
+} else if (!fs.existsSync('ios/test_credentials.json')) {
+    fs.writeFileSync('ios/test_credentials.json', '{}', 'utf8');
+}
 
 console.log('=== Creating index.ios.bundle');
 execSync('node ./updatebundle.js', {stdio: [0,1,2]});

--- a/iosTests/test_credentials.json
+++ b/iosTests/test_credentials.json
@@ -1,1 +1,0 @@
-../shared/test/test_credentials.json


### PR DESCRIPTION
## Summary

- Simplify test credentials: both `iosTests/` and `androidTests/` expect `test_credentials.json` at their root (removed `shared/test/` directory and symlink)
- Use `file:..` for `react-native-force` in test `package.json` — tests always run against local code, no push required
- Add Gradle task to copy `test_credentials.json` to assets at build time (no more ordering dependency with `prepareandroid.js`)
- Fix `react-android`/`hermes-android` version: `0.81.5` → `0.82.1`
- Update `.gitignore` for test artifacts
- CI workflows run `create_test_credentials_from_env.js` before prepare scripts

## Test plan

- [x] iOS tests build and pass (35/35) via Xcode
- [x] `prepareandroid.js` runs successfully
- [x] Android project builds and runs tests in Android Studio
- [x] Missing `test_credentials.json` prints a clear warning