### PR TITLE
[auto-generated] Fix CI: add error handlers to mobilesync test promises

### DIFF
--- a/test/mobilesync.test.js
+++ b/test/mobilesync.test.js
@@ -98,6 +98,10 @@ testSyncUp = () => {
         })
         .then((result) => {
             testDone();
+        })
+        .catch((error) => {
+            console.error('testSyncUp failed:', error);
+            assert.fail('testSyncUp failed: ' + error);
         });
 };
 
@@ -136,6 +140,10 @@ testSyncDown = () => {
         })
         .then((result) => {
             testDone();
+        })
+        .catch((error) => {
+            console.error('testSyncDown failed:', error);
+            assert.fail('testSyncDown failed: ' + error);
         });
 };
 
@@ -199,8 +207,12 @@ testReSync = () => {
             // Cleanup
             return Promise.all([netDel('contact', contactId), netDel('contact', otherContactId)]);
         })
-        .then((result) => { 
+        .then((result) => {
             testDone();
+        })
+        .catch((error) => {
+            console.error('testReSync failed:', error);
+            assert.fail('testReSync failed: ' + error);
         });
 };
 
@@ -257,8 +269,12 @@ testCleanResyncGhosts = () => {
             // Cleanup
             return netDel('contact', contactId);
         })
-        .then((result) => { 
+        .then((result) => {
             testDone();
+        })
+        .catch((error) => {
+            console.error('testCleanResyncGhosts failed:', error);
+            assert.fail('testCleanResyncGhosts failed: ' + error);
         });
 };
 
@@ -305,6 +321,10 @@ testGetSyncStatusDeleteSync = () => {
         })
         .then((result) => {
             testDone();
+        })
+        .catch((error) => {
+            console.error('testGetSyncStatusDeleteSync failed:', error);
+            assert.fail('testGetSyncStatusDeleteSync failed: ' + error);
         });
 };
 


### PR DESCRIPTION
## Summary
- Adds `.catch()` error handlers to all 5 test function promise chains in `test/mobilesync.test.js`
- On rejection, logs error via `console.error` and calls `assert.fail()` to ensure tests fail fast with descriptive messages
- Prevents silent 120-second test hangs when any server call fails or times out

## Root Cause
All 5 test functions (`testSyncUp`, `testSyncDown`, `testReSync`, `testCleanResyncGhosts`, `testGetSyncStatusDeleteSync`) had promise chains without `.catch()` handlers. When any server call failed, the chain silently broke — `testDone()` was never called, causing the native test runner to wait the full 120-second timeout before reporting failure.

## Test plan
- [ ] Verify `testCleanResyncGhosts` no longer hangs (may still fail due to server-side timing, but will fail fast with a clear error)
- [ ] Verify all other mobilesync tests still pass when server calls succeed
- [ ] Confirm this is test-only code — no production bridge code changes