### PR TITLE
Bump Android minSdk to 31

### DIFF
--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -79,7 +79,7 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=35,locale=en,orientation=portrait \
+            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 10m \
             --results-bucket cloud-test-${GITHUB_REPOSITORY_OWNER} \
             --results-dir "SalesforceReactNative/${GITHUB_RUN_ID}" \

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 28
+        minSdk 31
     }
 
     sourceSets {

--- a/androidTests/android/app/build.gradle.kts
+++ b/androidTests/android/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId = "com.salesforce.androidsdk.reactnative.tests"
-        minSdk = 28
+        minSdk = 31
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"

--- a/androidTests/android/build.gradle
+++ b/androidTests/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 28
+        minSdkVersion = 31
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"


### PR DESCRIPTION
## Summary
- Bumps `minSdk` from 28 to 31 in `android/build.gradle` (RN bridge module).
- Bumps `minSdkVersion`/`minSdk` from 28 to 31 in `androidTests/` test app.
- Bumps Firebase Test Lab device version from API 35 to 36 to align with the Android SDK repo's new PR default.

## Test plan
- [ ] CI: Android reusable workflow runs against API 36
- [ ] Manual: smoke-test RN sample app on an API 31 device

🤖 Generated with [Claude Code](https://claude.com/claude-code)