### PR TITLE
Revert react-native-force URL to forcedotcom#dev

### DIFF
--- a/androidTests/package.json
+++ b/androidTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.2.3",
     "react-native": "0.84.1",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.84"
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.2.3",
     "react-native": "0.84.1",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.84"
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
   },
   "devDependencies": {
     "chai": "4.4.1",


### PR DESCRIPTION
## Summary

- Reverts `react-native-force` in `iosTests/package.json` and `androidTests/package.json` from the temporary `wmathurin#rn-upgrade-0.84` fork reference back to `forcedotcom#dev`

## Context

The `wmathurin#rn-upgrade-0.84` URL was used during RN 0.84.1 upgrade development so that test apps could pull from the in-progress fork branch. Now that PR #461 has been merged, this reverts to the canonical reference.