### PR TITLE
W-22850908: Upgrade React Native from 0.85.3 to 0.86.0

### DIFF
--- a/.claude/skills/upgrade-react-native/SKILL.md
+++ b/.claude/skills/upgrade-react-native/SKILL.md
@@ -140,7 +140,14 @@ node prepareandroid.js
 
 This runs yarn install, clones SalesforceMobileSDK-Android, patches Gradle files, and builds the JS bundle.
 
-**Run Android tests** in Android Studio on emulator. Expect 35/35.
+**Run Android tests** from the command line. Use `numShards=1` to prevent the parallelism-induced `NetworkOnMainThreadException` flake in `testCleanResyncGhosts`:
+
+```bash
+cd android
+./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.numShards=1
+```
+
+Expect 35/35. Without `numShards=1`, `testCleanResyncGhosts` may timeout due to token refresh on the main thread under parallel load — passes in isolation, so this is a pre-existing emulator flake, not a regression.
 
 ---
 
@@ -257,6 +264,7 @@ GH_HOST=git.soma.salesforce.com gh pr create --repo SalesforceMobileSDK/Salesfor
 
 | RN Version | React Version | Hermes | Notable Changes |
 |------------|---------------|--------|-----------------|
+| 0.86.0 | 19.2.3 | — | No breaking changes; Android edge-to-edge fixes for API 36+; Metro 0.84.4; `PODFILE_DIR` added to pbxproj by pod install; use `numShards=1` for Android tests |
 | 0.85.3 | 19.2.3 | 250829098.0.10 | `StyleSheet.absoluteFillObject` removed (not used by us); Yoga migrated to Kotlin on Android (no impact); `rimraf` no longer transitive |
 | 0.84.1 | 19.2.3 | 250829098.0.9 | New Architecture default; bridgeless mode |
 | 0.83.9 | 19.2.6 | — | Black screen after login fix needed (Android `recreate()` in `onResume`) |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ kotlin {
 
 dependencies {
     api 'com.salesforce.mobilesdk:MobileSync:14.0.0'
-    api 'com.facebook.react:react-android:0.85.3'
+    api 'com.facebook.react:react-android:0.86.0'
     implementation 'androidx.core:core-ktx:1.18.0'
 }
 

--- a/androidTests/android/app/build.gradle.kts
+++ b/androidTests/android/app/build.gradle.kts
@@ -65,8 +65,8 @@ tasks.matching { it.name.startsWith("merge") && it.name.contains("Assets") }.con
 }
 
 dependencies {
-    implementation("com.facebook.react:react-android:0.85.3")
-    implementation("com.facebook.react:hermes-android:0.85.3")
+    implementation("com.facebook.react:react-android:0.86.0")
+    implementation("com.facebook.react:hermes-android:0.86.0")
 
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")

--- a/androidTests/package.json
+++ b/androidTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.86"
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/androidTests/package.json
+++ b/androidTests/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "create-react-class": "^15.7.0",
     "react": "19.2.3",
-    "react-native": "0.85.3",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
+    "react-native": "0.86.0",
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.86"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -21,10 +21,10 @@
     "@react-native-community/cli": "20.1.3",
     "@react-native-community/cli-platform-android": "20.1.3",
     "@react-native-community/cli-platform-ios": "20.1.3",
-    "@react-native/babel-preset": "0.85.3",
-    "@react-native/eslint-config": "0.85.3",
-    "@react-native/metro-config": "0.85.3",
-    "@react-native/typescript-config": "0.85.3",
+    "@react-native/babel-preset": "0.86.0",
+    "@react-native/eslint-config": "0.86.0",
+    "@react-native/metro-config": "0.86.0",
+    "@react-native/typescript-config": "0.86.0",
     "babel-jest": "^30.0.0",
     "metro-react-native-babel-preset": "0.77.0",
     "typescript": "^5.8.3"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -533,7 +533,7 @@ end
   "name": "react-native-force",
   "version": "14.0.0",
   "peerDependencies": {
-    "react-native": "0.85.3"
+    "react-native": "0.86.0"
   },
   "dependencies": {
     "react": "19.2.3",

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ The Android bridge lives in this repository at `android/`. It follows the same p
 
 | React Native SDK | React Native | iOS SDK | Android SDK | iOS Min | Android Min |
 |-----------------|--------------|---------|-------------|---------|-------------|
-| 14.0.0          | 0.85.3       | 14.0.0  | 14.0.0      | 18.0    | 31 (12.0)   |
+| 14.0.0          | 0.86.0       | 14.0.0  | 14.0.0      | 18.0    | 31 (12.0)   |
 
 See the [main README](../README.md) for the full version compatibility table.
 

--- a/docs/ios-tests/PREPAREIOS_DETAILED.md
+++ b/docs/ios-tests/PREPAREIOS_DETAILED.md
@@ -59,7 +59,7 @@ From `iosTests/package.json`:
 {
   "dependencies": {
     "react": "19.2.3",
-    "react-native": "0.85.3",
+    "react-native": "0.86.0",
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
   },
   "devDependencies": {
@@ -248,8 +248,8 @@ end
 === Installing pod dependencies
 Analyzing dependencies
 Downloading dependencies
-Installing React-Core (0.85.3)
-Installing React-hermes (0.85.3)
+Installing React-Core (0.86.0)
+Installing React-hermes (0.86.0)
 Installing SalesforceSDKCore (14.0.0)
 Installing SmartStore (14.0.0)
 Installing MobileSync (14.0.0)

--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -586,7 +586,7 @@ RCT_EXPORT_METHOD(someMethod:(NSDictionary *)args
 - **Xcode**: 15+
 - **CocoaPods**: 1.10+
 - **Node.js**: 22+
-- **React Native**: 0.85.3
+- **React Native**: 0.86.0
 
 ### Building Bridge Code
 

--- a/iosTests/ios/SalesforceReactTestApp.xcodeproj/project.pbxproj
+++ b/iosTests/ios/SalesforceReactTestApp.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 					"$(inherited)",
 					" ",
 				);
+				PODFILE_DIR = "$(SRCROOT)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -674,6 +675,7 @@
 					"$(inherited)",
 					" ",
 				);
+				PODFILE_DIR = "$(SRCROOT)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;

--- a/iosTests/ios/SalesforceReactTestApp/PrivacyInfo.xcprivacy
+++ b/iosTests/ios/SalesforceReactTestApp/PrivacyInfo.xcprivacy
@@ -23,18 +23,18 @@
 		</dict>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>E174.1</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
 			</array>
 		</dict>
 	</array>

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -12,7 +12,7 @@
     "create-react-class": "^15.7.0",
     "react": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.86"
+    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
   },
   "devDependencies": {
     "chai": "4.4.1",

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "create-react-class": "^15.7.0",
     "react": "19.2.3",
-    "react-native": "0.85.3",
-    "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
+    "react-native": "0.86.0",
+    "react-native-force": "git+https://github.com/wmathurin/SalesforceMobileSDK-ReactNative.git#rn-upgrade-0.86"
   },
   "devDependencies": {
     "chai": "4.4.1",
@@ -22,10 +22,10 @@
     "@react-native-community/cli": "20.1.3",
     "@react-native-community/cli-platform-android": "20.1.3",
     "@react-native-community/cli-platform-ios": "20.1.3",
-    "@react-native/babel-preset": "0.85.3",
-    "@react-native/eslint-config": "0.85.3",
-    "@react-native/metro-config": "0.85.3",
-    "@react-native/typescript-config": "0.85.3",
+    "@react-native/babel-preset": "0.86.0",
+    "@react-native/eslint-config": "0.86.0",
+    "@react-native/metro-config": "0.86.0",
+    "@react-native/typescript-config": "0.86.0",
     "@types/react": "^19.1.0",
     "@types/react-test-renderer": "^19.1.0",
     "babel-jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "postinstall": "node -e \"var fs=require('fs'),p=require('path');var src=p.resolve(__dirname,'android','generated','source','codegen');var dstDir=p.resolve(__dirname,'android','build','generated','source');var dst=p.join(dstDir,'codegen');if(fs.existsSync(src)&&!fs.existsSync(dst)){fs.mkdirSync(dstDir,{recursive:true});fs.symlinkSync(p.relative(dstDir,src),dst,'dir');}\""
   },
   "peerDependencies": {
-    "react-native": "0.85.3",
+    "react-native": "0.86.0",
     "react": ">=19.0.0"
   },
   "dependencies": {
@@ -77,10 +77,10 @@
     "@react-native-community/cli": "20.1.3",
     "@react-native-community/cli-platform-android": "20.1.3",
     "@react-native-community/cli-platform-ios": "20.1.3",
-    "@react-native/babel-preset": "0.85.3",
-    "@react-native/eslint-config": "0.85.3",
-    "@react-native/metro-config": "0.85.3",
-    "@react-native/typescript-config": "0.85.3",
+    "@react-native/babel-preset": "0.86.0",
+    "@react-native/eslint-config": "0.86.0",
+    "@react-native/metro-config": "0.86.0",
+    "@react-native/typescript-config": "0.86.0",
     "@types/react": "^19.1.0",
     "@types/react-test-renderer": "^19.1.0",
     "babel-jest": "^30.0.0",


### PR DESCRIPTION
## Summary

- `package.json`: `react-native` peer dep `0.85.3` → `0.86.0`; `@react-native/*` devDeps → `0.86.0`
- `iosTests/package.json` + `androidTests/package.json`: same bumps
- `android/build.gradle`: `react-android` → `0.86.0`
- `androidTests/android/app/build.gradle.kts`: `react-android` / `hermes-android` → `0.86.0`
- `iosTests/ios/SalesforceReactTestApp.xcodeproj/project.pbxproj`: `PODFILE_DIR` setting added by pod install (new in RN 0.86 CocoaPods integration)
- `iosTests/ios/SalesforceReactTestApp/PrivacyInfo.xcprivacy`: two entries reordered (cosmetic)
- Android codegen regenerated — output identical (no spec changes)
- `.claude/skills/upgrade-react-native/SKILL.md`: documented `numShards=1` fix for Android test flake; added 0.86.0 to version history

## RN 0.86 highlights

No breaking changes. Key improvements relevant to us:
- Android edge-to-edge fixes for Android 15+ (`measureInWindow`, `KeyboardAvoidingView`, `Dimensions`, `StatusBar`)
- `BackHandler` re-registration fix on Android API 36+
- Metro bumped to `^0.84.2` (running as 0.84.4)

## Test results

| Suite | iOS | Android |
|-------|-----|---------|
| ReactHarnessTests | 2/2 ✅ | 2/2 ✅ |
| ReactOAuthTests | 1/1 ✅ | 1/1 ✅ |
| ReactNetTests | 18/18 ✅ | 18/18 ✅ |
| ReactSmartStoreTests | 11/11 ✅ | 11/11 ✅ |
| ReactMobileSyncTests | 5/5 ✅ | 5/5 ✅ |
| **Total** | **35/35** ✅ | **35/35** ✅ |

Android tests run with `-Pandroid.testInstrumentationRunnerArguments.numShards=1` — `testCleanResyncGhosts` flakes under parallel load due to a pre-existing `NetworkOnMainThreadException` in the emulator's AccountManager; passes reliably sequentially.

## ⚠️ Before Merging

Revert `react-native-force` URLs in `iosTests/package.json` and `androidTests/package.json` from `wmathurin#rn-upgrade-0.86` back to `forcedotcom#dev`.