### PR TITLE
chore: housekeeping cleanup after SDK 14.0.0 / RN 0.85.3 upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,9 @@ JS: net.sendRequest(...)
 ## Build & Test Setup
 
 ### Prerequisites
-- **Node.js**: 20+ (see `package.json` engines)
+- **Node.js**: 22+ (see `package.json` engines)
 - **TypeScript**: Installed via devDependencies
-- **iOS Development**: Xcode 15+, macOS
+- **iOS Development**: Xcode 16+, macOS
 - **Android Development**: For Android bridge testing, see `androidTests/`
 
 ### Build JavaScript/TypeScript

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install react-native-force
 
 - **Node.js**: 22 or higher
 - **React Native**: 0.85.3 (see `package.json` for current version)
-- **iOS Development**: Xcode 15+, macOS (for iOS builds)
+- **iOS Development**: Xcode 16+, macOS (for iOS builds)
 - **Android Development**: Android Studio, Java 17+ (for Android builds)
 
 ### Creating a New App

--- a/SalesforceReact.podspec
+++ b/SalesforceReact.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
       salesforcereact.dependency 'SmartStore', "~>#{s.version}"
       salesforcereact.dependency 'MobileSync', "~>#{s.version}"
       salesforcereact.source_files = 'ios/SalesforceReact/**/*.{h,m,mm}'
-      salesforcereact.public_header_files = 'ios/SalesforceReact/SFNetReactBridge.h', 'ios/SalesforceReact/SFOauthReactBridge.h', 'ios/SalesforceReact/SFSDKReactLogger.h', 'ios/SalesforceReact/SFSmartStoreReactBridge.h', 'ios/SalesforceReact/SFMobileSyncReactBridge.h', 'libs/SalesforceReact/SalesforceReact/SalesforceReact.h', 'ios/SalesforceReact/SalesforceReactSDKManager.h'
+      salesforcereact.public_header_files = 'ios/SalesforceReact/SFNetReactBridge.h', 'ios/SalesforceReact/SFOauthReactBridge.h', 'ios/SalesforceReact/SFSDKReactLogger.h', 'ios/SalesforceReact/SFSmartStoreReactBridge.h', 'ios/SalesforceReact/SFMobileSyncReactBridge.h', 'ios/SalesforceReact/SalesforceReactSDKManager.h'
       salesforcereact.prefix_header_contents = '#import "SFSDKReactLogger.h"'
       salesforcereact.requires_arc = true
 

--- a/androidTests/package.json
+++ b/androidTests/package.json
@@ -26,7 +26,6 @@
     "@react-native/metro-config": "0.85.3",
     "@react-native/typescript-config": "0.85.3",
     "babel-jest": "^30.0.0",
-    "metro-react-native-babel-preset": "0.77.0",
     "typescript": "^5.8.3"
   },
   "engines": {

--- a/docs/android-tests/PREPAREANDROID_DETAILED.md
+++ b/docs/android-tests/PREPAREANDROID_DETAILED.md
@@ -83,6 +83,6 @@ The `app/build.gradle.kts` includes a `copyTestCredentials` task that runs befor
 | Issue | Cause | Fix |
 |-------|-------|-----|
 | `Failed to read test_credentials.json` at runtime | Missing or empty credentials file | Place valid credentials at `shared/test/test_credentials.json` |
-| `yarn install` fails | Network issue or incompatible Node version | Ensure Node 20+, check network |
+| `yarn install` fails | Network issue or incompatible Node version | Ensure Node 22+, check network |
 | Gradle build fails with dependency errors | Stale `mobile_sdk/` clone | Delete `mobile_sdk/` and re-run |
 | Bundle fails with Metro error | Incompatible babel config | Delete `node_modules/` and re-run |

--- a/docs/android-tests/README.md
+++ b/docs/android-tests/README.md
@@ -433,7 +433,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '20'
+        node-version: '22'
     
     - name: Setup Java
       uses: actions/setup-java@v3

--- a/docs/ios-tests/README.md
+++ b/docs/ios-tests/README.md
@@ -127,8 +127,8 @@ iosTests/
 
 ### Prerequisites
 
-- **Xcode**: 15 or later
-- **Node.js**: 20 or later
+- **Xcode**: 16 or later
+- **Node.js**: 22 or later
 - **CocoaPods**: 1.10 or later
 - **Salesforce Org**: For authentication tests
 
@@ -793,7 +793,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '20'
+        node-version: '22'
     
     - name: Setup Test Credentials
       env:

--- a/iosTests/package.json
+++ b/iosTests/package.json
@@ -15,7 +15,6 @@
     "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
   },
   "devDependencies": {
-    "chai": "4.4.1",
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
@@ -31,7 +30,6 @@
     "babel-jest": "^30.0.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
-    "metro-react-native-babel-preset": "0.77.0",
     "prettier": "2.8.8",
     "react-test-renderer": "19.2.3",
     "typescript": "^5.8.3"

--- a/setversion.sh
+++ b/setversion.sh
@@ -2,6 +2,21 @@
 
 #set -x
 
+# SCOPE: This script only stamps the Mobile SDK *version* number — the
+# package.json "version" field, the SalesforceMobileSDK git tag in the test
+# apps' package.json, and s.version in SalesforceReact.podspec — then rebuilds
+# dist/ and the Android codegen.
+#
+# It does NOT update the React Native platform/toolchain values. Those must be
+# bumped MANUALLY on each upgrade and kept in sync with the "Version
+# Compatibility" table in README.md:
+#   - react-native / react / @react-native-* / @react-native-community/cli
+#     versions in package.json, iosTests/package.json, androidTests/package.json,
+#     and react-android/hermes-android in androidTests/android/app/build.gradle.kts
+#   - iOS minimum deployment target: SalesforceReact.podspec (s.platform),
+#     iosTests/ios/Podfile, and IPHONEOS_DEPLOYMENT_TARGET in project.pbxproj
+#   - Android minSdk: android/build.gradle and androidTests/android build files
+
 OPT_VERSION=""
 RED='\033[0;31m'
 YELLOW='\033[0;33m'


### PR DESCRIPTION
## Summary

An audit against the **14.0.0 / RN 0.85.3 / iOS 18.0 / Android 31** version matrix (the row published in `README.md`) found the repo **already meets the matrix** in every place that defines it — `package.json`, `SalesforceReact.podspec`, `android/build.gradle`, both test apps, and CI are all at target. The RN 0.85.3 and iOS 18 work landed in earlier PRs.

This PR cleans up the **leftovers** that the version bump didn't catch. No public API, dependency version, or build-matrix value is changed.

## Changes

**Docs — stale toolchain minimums** (engines.node is `>=22`; the iOS 18 SDK requires Xcode 16+; CI already uses Node 22 / Xcode `^16`):
- `README.md`: Xcode 15+ → 16+
- `CLAUDE.md`: Node 20+ → 22+, Xcode 15+ → 16+
- `docs/ios-tests/README.md`: Xcode 15 → 16, Node 20 → 22, and CI example `node-version: '20'` → `'22'`
- `docs/android-tests/README.md`: CI example `node-version: '20'` → `'22'`
- `docs/android-tests/PREPAREANDROID_DETAILED.md`: "Node 20+" → "Node 22+"

**Dead dependencies in the test apps:**
- `iosTests/package.json`: removed `chai@4.4.1` (replaced by the custom `assert.js` per CLAUDE.md; no longer imported) and the deprecated `metro-react-native-babel-preset@0.77.0` (superseded by `@react-native/babel-preset@0.85.3`)
- `androidTests/package.json`: removed the same deprecated `metro-react-native-babel-preset@0.77.0`

**Podspec — dead header path:**
- `SalesforceReact.podspec`: removed `libs/SalesforceReact/SalesforceReact/SalesforceReact.h` from `public_header_files`. That path is from the pre-14.0 layout (before the bridge moved to `ios/SalesforceReact/`); the umbrella header no longer exists, so CocoaPods warned on the non-matching glob.

**Release tooling — documentation:**
- `setversion.sh`: added a SCOPE comment clarifying it stamps only the SDK *version* (package.json version, SDK git tag, podspec `s.version`) and that the RN / iOS-min / `minSdk` toolchain values must be bumped manually each upgrade and kept in sync with the README compatibility table.

## Verification
- Both edited `package.json` files validate as JSON.
- Repo-wide sweep confirms no remaining `Xcode 15`, `Node 20`, `chai`, `metro-react-native-babel-preset`, or `libs/SalesforceReact` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)