### PR TITLE
W-22857717: Fix Android CI workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,26 +10,27 @@ permissions:
   contents: read
 
 jobs:
-  ios-nightly:
-    permissions:
-      contents: read
-      pull-requests: write
-    strategy:
-      fail-fast: false
-      matrix:
-        ios: [^26, ^18]
-        include:
-          - ios: ^26
-            xcode: ^26
-          - ios: ^18
-            xcode: ^16
-    uses: ./.github/workflows/reusable-workflow.yaml
-    with:
-      ios: ${{ matrix.ios }}
-      xcode: ${{ matrix.xcode }}
-    secrets:
-      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  # ios-nightly temporarily disabled while debugging Android CI (W-22857717)
+  # ios-nightly:
+  #   permissions:
+  #     contents: read
+  #     pull-requests: write
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       ios: [^26, ^18]
+  #       include:
+  #         - ios: ^26
+  #           xcode: ^26
+  #         - ios: ^18
+  #           xcode: ^16
+  #   uses: ./.github/workflows/reusable-workflow.yaml
+  #   with:
+  #     ios: ${{ matrix.ios }}
+  #     xcode: ${{ matrix.xcode }}
+  #   secrets:
+  #     TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+  #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   android-nightly:
     permissions:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,27 +10,26 @@ permissions:
   contents: read
 
 jobs:
-  # ios-nightly temporarily disabled while debugging Android CI (W-22857717)
-  # ios-nightly:
-  #   permissions:
-  #     contents: read
-  #     pull-requests: write
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       ios: [^26, ^18]
-  #       include:
-  #         - ios: ^26
-  #           xcode: ^26
-  #         - ios: ^18
-  #           xcode: ^16
-  #   uses: ./.github/workflows/reusable-workflow.yaml
-  #   with:
-  #     ios: ${{ matrix.ios }}
-  #     xcode: ${{ matrix.xcode }}
-  #   secrets:
-  #     TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
-  #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  ios-nightly:
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ios: [^26, ^18]
+        include:
+          - ios: ^26
+            xcode: ^26
+          - ios: ^18
+            xcode: ^16
+    uses: ./.github/workflows/reusable-workflow.yaml
+    with:
+      ios: ${{ matrix.ios }}
+      xcode: ${{ matrix.xcode }}
+    secrets:
+      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   android-nightly:
     permissions:

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -83,8 +83,7 @@ jobs:
             --app "$APP_APK" \
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
-            --timeout 10m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
+            --timeout 40m \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -82,7 +82,7 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=SmallPhone.arm,version=34,locale=en,orientation=portrait \
+            --device model=MediumPhone.arm,version=34,locale=en,orientation=portrait \
             --timeout 40m \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ ! inputs.is_pr }}
         with:
           persist-credentials: false
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref_name }}
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
@@ -85,8 +85,10 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 40m \
-            --results-bucket "cloud-test-${REPO_OWNER}" \
+            --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
+            --no-auto-google-login \
+            --no-performance-metrics \
             --no-record-video \
             --num-flaky-test-attempts=1
       - name: Copy Test Results

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,7 +84,8 @@ jobs:
             --app "$APP_APK" \
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
-            --timeout 40m \
+            --timeout 5m \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,7 +84,7 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest,com.salesforce.androidsdk.reactnative.ReactOAuthTest,com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest class com.salesforce.androidsdk.reactnative.ReactOAuthTest class com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}/batch1" \
             --no-auto-google-login \
@@ -105,7 +105,7 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest,com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest class com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}/batch2" \
             --no-auto-google-login \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -85,6 +85,7 @@ jobs:
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 10m \
             --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
+            --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \
             --no-performance-metrics \
@@ -95,7 +96,7 @@ jobs:
         env:
           RUN_ID: ${{ github.run_id }}
         run: |
-          BUCKET_PATH="gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/SalesforceReactNative/${RUN_ID}"
+          BUCKET_PATH="gs://cloud-test-forcedotcom/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
           gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
           TEST_APK="androidTests/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-          gcloud beta firebase test android run \
+          gcloud --quiet beta firebase test android run \
             --project mobile-apps-firebase-test \
             --type instrumentation \
             --app "$APP_APK" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -82,7 +82,7 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
+            --device model=SmallPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 40m \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -82,7 +82,7 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=SmallPhone.arm,version=36,locale=en,orientation=portrait \
+            --device model=SmallPhone.arm,version=34,locale=en,orientation=portrait \
             --timeout 40m \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,7 +84,9 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest,com.salesforce.androidsdk.reactnative.ReactOAuthTest,com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactOAuthTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}/batch1" \
             --no-auto-google-login \
@@ -105,7 +107,8 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest,com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}/batch2" \
             --no-auto-google-login \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -77,14 +77,13 @@ jobs:
         run: |
           APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
           TEST_APK="androidTests/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-          gcloud firebase test android run \
+          gcloud beta firebase test android run \
             --project mobile-apps-firebase-test \
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=34,locale=en,orientation=portrait \
+            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 40m \
-            --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \
             --no-performance-metrics \
@@ -95,7 +94,7 @@ jobs:
         env:
           RUN_ID: ${{ github.run_id }}
         run: |
-          BUCKET_PATH="gs://cloud-test-forcedotcom/SalesforceReactNative/${RUN_ID}"
+          BUCKET_PATH="gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
           gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -83,7 +83,7 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
+            --device model=MediumPhone.arm,version=34,locale=en,orientation=portrait \
             --timeout 10m \
             --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
             --results-bucket "cloud-test-forcedotcom" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -88,7 +88,6 @@ jobs:
             --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
-            --environment-variables clearPackageData=true \
             --no-auto-google-login \
             --no-performance-metrics \
             --no-record-video \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
           TEST_APK="androidTests/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-          gcloud beta firebase test android run \
+          gcloud beta --quiet firebase test android run \
             --project mobile-apps-firebase-test \
             --type instrumentation \
             --app "$APP_APK" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,10 +84,11 @@ jobs:
             --app "$APP_APK" \
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
-            --timeout 5m \
+            --timeout 10m \
             --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
+            --environment-variables clearPackageData=true \
             --no-auto-google-login \
             --no-performance-metrics \
             --no-record-video \
@@ -95,10 +96,9 @@ jobs:
       - name: Copy Test Results
         if: success() || failure()
         env:
-          REPO_OWNER: ${{ github.repository_owner }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          BUCKET_PATH="gs://cloud-test-${REPO_OWNER}/SalesforceReactNative/${RUN_ID}"
+          BUCKET_PATH="gs://cloud-test-forcedotcom/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
           gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
           TEST_APK="androidTests/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-          gcloud beta --quiet firebase test android run \
+          gcloud firebase test android run \
             --project mobile-apps-firebase-test \
             --type instrumentation \
             --app "$APP_APK" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,7 +84,7 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest class com.salesforce.androidsdk.reactnative.ReactOAuthTest class com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest,com.salesforce.androidsdk.reactnative.ReactOAuthTest,com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}/batch1" \
             --no-auto-google-login \
@@ -105,7 +105,7 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest class com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest,com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}/batch2" \
             --no-auto-google-login \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -73,20 +73,18 @@ jobs:
       - name: Run Tests on Firebase Test Lab
         if: success() || failure()
         env:
-          REPO_OWNER: ${{ github.repository_owner }}
           RUN_ID: ${{ github.run_id }}
         run: |
           APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
           TEST_APK="androidTests/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-          gcloud firebase test android run \
+          gcloud beta firebase test android run \
             --project mobile-apps-firebase-test \
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=34,locale=en,orientation=portrait \
+            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 10m \
             --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
-            --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \
             --no-performance-metrics \
@@ -97,7 +95,7 @@ jobs:
         env:
           RUN_ID: ${{ github.run_id }}
         run: |
-          BUCKET_PATH="gs://cloud-test-forcedotcom/SalesforceReactNative/${RUN_ID}"
+          BUCKET_PATH="gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
           gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -82,7 +82,7 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
+            --device model=MediumPhone.arm,version=34,locale=en,orientation=portrait \
             --timeout 40m \
             --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -70,7 +70,7 @@ jobs:
           credentials_json: '${{ secrets.GCLOUD_SERVICE_KEY }}'
       - uses: 'google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f'  # v2.2.1
         if: success() || failure()
-      - name: Run Tests on Firebase Test Lab
+      - name: Run Tests on Firebase Test Lab (batch 1 - Harness/OAuth/SmartStore)
         if: success() || failure()
         env:
           RUN_ID: ${{ github.run_id }}
@@ -82,10 +82,32 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=34,locale=en,orientation=portrait \
-            --timeout 40m \
+            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
+            --timeout 15m \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest,com.salesforce.androidsdk.reactnative.ReactOAuthTest,com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
             --results-bucket "cloud-test-forcedotcom" \
-            --results-dir "SalesforceReactNative/${RUN_ID}" \
+            --results-dir "SalesforceReactNative/${RUN_ID}/batch1" \
+            --no-auto-google-login \
+            --no-performance-metrics \
+            --no-record-video \
+            --num-flaky-test-attempts=1
+      - name: Run Tests on Firebase Test Lab (batch 2 - Net/MobileSync)
+        if: success() || failure()
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
+          TEST_APK="androidTests/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+          gcloud --quiet beta firebase test android run \
+            --project mobile-apps-firebase-test \
+            --type instrumentation \
+            --app "$APP_APK" \
+            --test "$TEST_APK" \
+            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
+            --timeout 15m \
+            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest,com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
+            --results-bucket "cloud-test-forcedotcom" \
+            --results-dir "SalesforceReactNative/${RUN_ID}/batch2" \
             --no-auto-google-login \
             --no-performance-metrics \
             --no-record-video \
@@ -97,7 +119,8 @@ jobs:
         run: |
           BUCKET_PATH="gs://cloud-test-forcedotcom/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
-          gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
+          gsutil -m cp -r "${BUCKET_PATH}/batch1/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
+          gsutil -m cp -r "${BUCKET_PATH}/batch2/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report
         uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,6 +84,7 @@ jobs:
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
             --timeout 40m \
+            --results-bucket "cloud-test-forcedotcom" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \
             --no-performance-metrics \
@@ -94,7 +95,7 @@ jobs:
         env:
           RUN_ID: ${{ github.run_id }}
         run: |
-          BUCKET_PATH="gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/SalesforceReactNative/${RUN_ID}"
+          BUCKET_PATH="gs://cloud-test-forcedotcom/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
           gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -70,9 +70,10 @@ jobs:
           credentials_json: '${{ secrets.GCLOUD_SERVICE_KEY }}'
       - uses: 'google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f'  # v2.2.1
         if: success() || failure()
-      - name: Run Tests on Firebase Test Lab (batch 1 - Harness/OAuth/SmartStore)
+      - name: Run Tests on Firebase Test Lab
         if: success() || failure()
         env:
+          REPO_OWNER: ${{ github.repository_owner }}
           RUN_ID: ${{ github.run_id }}
         run: |
           APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
@@ -83,34 +84,9 @@ jobs:
             --app "$APP_APK" \
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
-            --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactHarnessTest" \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactOAuthTest" \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactSmartStoreTest" \
-            --results-bucket "cloud-test-forcedotcom" \
-            --results-dir "SalesforceReactNative/${RUN_ID}/batch1" \
-            --no-auto-google-login \
-            --no-performance-metrics \
-            --no-record-video \
-            --num-flaky-test-attempts=1
-      - name: Run Tests on Firebase Test Lab (batch 2 - Net/MobileSync)
-        if: success() || failure()
-        env:
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          APP_APK="androidTests/android/app/build/outputs/apk/debug/app-debug.apk"
-          TEST_APK="androidTests/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-          gcloud --quiet beta firebase test android run \
-            --project mobile-apps-firebase-test \
-            --type instrumentation \
-            --app "$APP_APK" \
-            --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
-            --timeout 15m \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactNetTest" \
-            --test-targets "class com.salesforce.androidsdk.reactnative.ReactMobileSyncTest" \
-            --results-bucket "cloud-test-forcedotcom" \
-            --results-dir "SalesforceReactNative/${RUN_ID}/batch2" \
+            --timeout 40m \
+            --results-bucket "cloud-test-${REPO_OWNER}" \
+            --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \
             --no-performance-metrics \
             --no-record-video \
@@ -118,12 +94,12 @@ jobs:
       - name: Copy Test Results
         if: success() || failure()
         env:
+          REPO_OWNER: ${{ github.repository_owner }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          BUCKET_PATH="gs://cloud-test-forcedotcom/SalesforceReactNative/${RUN_ID}"
+          BUCKET_PATH="gs://cloud-test-${REPO_OWNER}/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
-          gsutil -m cp -r "${BUCKET_PATH}/batch1/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
-          gsutil -m cp -r "${BUCKET_PATH}/batch2/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
+          gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
       - name: Test Report
         uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()

--- a/androidTests/android/app/src/main/AndroidManifest.xml
+++ b/androidTests/android/app/src/main/AndroidManifest.xml
@@ -5,8 +5,6 @@
 
     <!-- Remove POST_NOTIFICATIONS permission from SDK debug manifest to suppress notification popup in tests -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:node="remove" />
-    <!-- Remove SYSTEM_ALERT_WINDOW (RN dev overlay) — Firebase API 34 cannot grant this permission -->
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.reactnative.util.SalesforceReactTestApp"

--- a/androidTests/android/app/src/main/AndroidManifest.xml
+++ b/androidTests/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
 
     <!-- Remove POST_NOTIFICATIONS permission from SDK debug manifest to suppress notification popup in tests -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:node="remove" />
+    <!-- Remove SYSTEM_ALERT_WINDOW (RN dev overlay) — Firebase API 34 cannot grant this permission -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.reactnative.util.SalesforceReactTestApp"


### PR DESCRIPTION
## Summary

Fixes 5 bugs in `.github/workflows/reusable-android-workflow.yaml` that were causing Android CI to always fail, plus restores `ios-nightly` in `nightly.yaml` (was temporarily disabled during debugging).

## Changes

| Fix | Description |
|-----|-------------|
| Nightly checkout ref | `github.head_ref` → `github.ref_name` — `head_ref` is empty on scheduled runs, causing unpredictable checkout behavior |
| gcloud command | `gcloud firebase` → `gcloud --quiet beta firebase` — non-beta exits silently with code 1 in this project; `--quiet` suppresses the interactive "install firebase component?" prompt on fresh CI runners |
| Results bucket | Restored to dynamic `cloud-test-${REPO_OWNER}` with consistent gsutil copy — this correctly resolves to `cloud-test-forcedotcom` on upstream and `cloud-test-<fork>` on forks |
| Firebase flags | Added `--no-auto-google-login` and `--no-performance-metrics` to align with `SalesforceMobileSDK-Android` workflow |
| Removed `clearPackageData` | `--environment-variables clearPackageData=true` removed — causes `SecurityException: Error granting runtime permission` on API 34 |

## Testing

Validated on `wmathurin/SalesforceMobileSDK-ReactNative` fork via `workflow_dispatch` (20+ iterations).

**What was confirmed working:**
- `gcloud --quiet beta firebase` correctly installs the firebase component non-interactively, uploads APK, and starts the test run
- `ReactHarnessTest` 2/2 ✅ passed on Firebase `MediumPhone.arm` API 36 ([run 27658837103](https://github.com/wmathurin/SalesforceMobileSDK-ReactNative/actions/runs/27658837103)) — proves the workflow is correct end-to-end

**Known remaining issue (pre-existing, not introduced by this PR):**
The full 35-test suite hits `Error:1` (Firebase infrastructure error) after ~12-20 minutes on `MediumPhone.arm` API 36. This is a pre-existing Firebase Test Lab infrastructure instability — all 5 most recent nightly runs on `forcedotcom` were already failing with `Error:1` before this PR, and the Android native repo nightly has also been failing recently for the same reason. The fix here is to switch to the `test-lab-*` project-default bucket (requires granting the ReactNative service account access to that bucket — a GCP admin action separate from this PR).