### PR TITLE
W-22857717: Fix Android CI (API 36 instability, timeout limit, results collection)

### DIFF
--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,12 +84,13 @@ jobs:
             --app "$APP_APK" \
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=35,locale=en,orientation=portrait \
-            --timeout 90m \
+            --timeout 60m \
             --results-bucket "cloud-test-${REPO_OWNER}" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \
             --no-performance-metrics \
             --no-record-video \
+            --num-uniform-shards=2 \
             --num-flaky-test-attempts=1
       - name: Copy Test Results
         if: success() || failure()
@@ -99,7 +100,11 @@ jobs:
         run: |
           BUCKET_PATH="gs://cloud-test-${REPO_OWNER}/SalesforceReactNative/${RUN_ID}"
           mkdir -p firebase_results
-          gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
+          if gsutil ls "${BUCKET_PATH}/*test_results_merged.xml" > /dev/null 2>&1; then
+            gsutil cp "${BUCKET_PATH}/*test_results_merged.xml" firebase_results/test_result.xml
+          else
+            gsutil -m cp -r "${BUCKET_PATH}/*/test_result_1.xml" firebase_results/ 2>/dev/null || true
+          fi
       - name: Test Report
         uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -84,7 +84,7 @@ jobs:
             --app "$APP_APK" \
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=35,locale=en,orientation=portrait \
-            --timeout 60m \
+            --timeout 90m \
             --results-bucket "cloud-test-${REPO_OWNER}" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \

--- a/.github/workflows/reusable-android-workflow.yaml
+++ b/.github/workflows/reusable-android-workflow.yaml
@@ -83,8 +83,8 @@ jobs:
             --type instrumentation \
             --app "$APP_APK" \
             --test "$TEST_APK" \
-            --device model=MediumPhone.arm,version=36,locale=en,orientation=portrait \
-            --timeout 40m \
+            --device model=MediumPhone.arm,version=35,locale=en,orientation=portrait \
+            --timeout 60m \
             --results-bucket "cloud-test-${REPO_OWNER}" \
             --results-dir "SalesforceReactNative/${RUN_ID}" \
             --no-auto-google-login \


### PR DESCRIPTION
## Summary

The nightly Android CI workflow (`reusable-android-workflow.yaml`) has been consistently failing. This PR fixes 6 bugs identified through iterative debugging.

## Root Causes Fixed

### 1. Wrong `ref` for scheduled/nightly runs
`github.head_ref` is only populated for pull request events — it's empty on scheduled runs, causing checkout to silently fall back to the default branch.
- **Fix:** Use `github.ref_name` for non-PR runs.

### 2. Firebase project timeout cap (60 min max)
The `mobile-apps-firebase-test` project caps test timeouts at 60 minutes. With `--timeout 90m` the API returns HTTP 400 immediately. The test suite takes ~70 min on a single CI device.
- **Fix:** Use `--num-uniform-shards=2` to split tests across 2 devices (~35 min each) within the 60 min cap.

### 3. API 36 infrastructure instability (`Error:1`)
`MediumPhone.arm` API 36 consistently exits with `Error:1` after ~12–20 min on the `cloud-test-forcedotcom` project — a known Firebase Test Lab infrastructure issue.
- **Fix:** Use API 35, which is stable and runs the full 35-test suite.

### 4. Missing `--results-bucket`
Without an explicit bucket, `gcloud` tries to use the project-default bucket (`test-lab-*`) which the service account doesn't have write access to (403).
- **Fix:** Use `--results-bucket "cloud-test-${REPO_OWNER}"` (evaluates to `cloud-test-forcedotcom` on the upstream repo).

### 5. Wrong `gcloud` flag order (`--quiet` position)
`gcloud beta --quiet firebase` does not suppress the interactive component install prompt. `--quiet` must precede `beta`.
- **Fix:** Use `gcloud --quiet beta firebase test android run`.

### 6. Result collection didn't handle sharded runs
Firebase generates `test_results_merged.xml` at the matrix level for sharded runs. The old `gsutil` glob only looked for per-shard `test_result_1.xml`.
- **Fix:** Prefer `test_results_merged.xml` when present; fall back to per-shard files.

## Validation

**Local (Firebase Test Lab, API 35, single device, 60 min):**
- `local-test-5`: 35 tests ran, 34 passed, 1 flaky failure (`testSyncUp` — pre-existing timeout flake). ✅

**Fork CI runs (wmathurin/SalesforceMobileSDK-ReactNative):**
- Run [27987509273](https://github.com/wmathurin/SalesforceMobileSDK-ReactNative/actions/runs/27987509273) — 2 shards ran to completion, 35 tests ran, 27 passed, 7 flaky (passed on retry via `--num-flaky-test-attempts=1`), 1 failed (`testSyncUp` — pre-existing timeout flake unrelated to this change). ✅

**`testSyncUp` pre-existing flakiness:** This test times out intermittently waiting for a Salesforce API response. It was already failing before this PR and is tracked separately.