### PR TITLE
feat(W-23159740): use per-user UA string in SFOauthReactBridge

### DIFF
--- a/ios/SalesforceReact/SFOauthReactBridge.mm
+++ b/ios/SalesforceReact/SFOauthReactBridge.mm
@@ -96,7 +96,8 @@ RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderB
         NSString *instanceUrl = creds.instanceUrl.absoluteString;
         NSString *loginUrl = [NSString stringWithFormat:@"%@://%@", creds.protocol, creds.domain];
         NSString *communityUrl = creds.communityUrl ? creds.communityUrl.absoluteString : nil;
-        NSString *uaString = [SalesforceSDKManager sharedManager].userAgentString(@"");
+        SFUserAccount *currentUser = [SFUserAccountManager sharedInstance].currentUser;
+        NSString *uaString = [[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:currentUser];
         NSDictionary* credentialsDict = @{kAccessTokenCredentialsDictKey: creds.accessToken,
                                           kRefreshTokenCredentialsDictKey: creds.refreshToken,
                                           kClientIdCredentialsDictKey: creds.clientId,


### PR DESCRIPTION
## Summary

- `SFOauthReactBridge.mm`: passes `currentUser` to `userAgentString:@"" forUser:currentUser` so per-user feature flags are included in the User-Agent string returned to React Native during authentication

## GUS Stories
- W-23159740 (iOS per-user feature flags)
- W-21167151 (spike)

## Dependencies
- Requires PR forcedotcom/SalesforceMobileSDK-iOS#4086

## Test plan
- [x] Code review — single-method change
- [ ] Integration tests (require sandbox credentials — run in CI)