### PR TITLE
W-23212499: Fix iOS 18 / Xcode 16 CI jobs broken by macos-latest → macOS 26 migration

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,10 +23,12 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
     secrets:
       TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,11 +57,13 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       is_pr: true
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
     secrets:
       TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- GitHub migrated `macos-latest` to macOS 26 on June 15, 2026
- macOS 26 ships with Xcode 26 only — no Xcode 16 or iOS 18 simulators
- The `ios: ^18` / `xcode: ^16` matrix entries in `pr.yaml` and `nightly.yaml` were breaking because they inherited `macos-latest`

## Changes
- Added `macos: macos-15` to the `ios: ^18` / `xcode: ^16` matrix `include` entry in both `.github/workflows/pr.yaml` (`ios-pr` job) and `.github/workflows/nightly.yaml` (`ios-nightly` job)
- Passed `macos: ${{ matrix.macos }}` through to the `with:` block of each reusable workflow call
- The `ios: ^26` / `xcode: ^26` entries are unaffected (they should use `macos-latest` → macOS 26)
- The reusable workflow (`reusable-workflow.yaml`) already accepts a `macos` input with `default: macos-latest` — no changes needed there

## Test plan
- [ ] Verify `ios-pr` matrix shows two runners: `macos-latest` (for `^26`) and `macos-15` (for `^18`)
- [ ] Verify `ios-nightly` matrix shows the same split
- [ ] Confirm iOS 18 simulator tests pass on the `macos-15` runner