### PR TITLE
fix(ci): restore the iOS 26 test leg dropped from PR and nightly runs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,6 +21,7 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
+            macos: macos-latest
           - ios: ^18
             xcode: ^16
             macos: macos-15

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,6 +55,7 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
+            macos: macos-latest
           - ios: ^18
             xcode: ^16
             macos: macos-15


### PR DESCRIPTION
## Problem

`pr.yaml` and `nightly.yaml` pass `macos: ${{ matrix.macos }}` to the reusable iOS workflow, but only the `^18` matrix leg defines `macos`:

```yaml
matrix:
  ios: [^26, ^18]
  include:
    - ios: ^26
      xcode: ^26          # no macos
    - ios: ^18
      xcode: ^16
      macos: macos-15
```

For the `^26` leg `matrix.macos` is undefined, so an **empty string** is passed to the reusable workflow. That empty string overrides the callee's `macos: { default: macos-latest }`, leaving `runs-on: ${{ inputs.macos }}` empty — and GitHub creates **no job** for that leg: no run, no failure, no "skipped".

**Effect:** since this was introduced, every nightly and every PR has executed **zero iOS 26 / Xcode 26 tests**, while the iOS side of the run still reports green (only the `^18` leg runs). A regression that only surfaces on the newest iOS/Xcode lane — the primary support target — merges and ships with CI green, and nobody is told the leg is missing.

This was confirmed against the live GitHub jobs API: nightly runs after the change contain only 2 jobs (android + iOS `^18`), with no `^26` job in any state.

## Fix

Add `macos: macos-latest` to the `^26` include entry in both `pr.yaml` and `nightly.yaml`, so the input is never an empty string and the leg runs on the default runner again.

## Test plan

- [ ] Confirm the next PR/nightly run contains the iOS `^26` job again (4 jobs total: android + iOS `^26` + iOS `^18`, plus the permission gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CGbVaRKrx7DeurX81NWdQ