### PR TITLE
fix(net): join array fieldlist in net.retrieve so the documented usage works

### DIFF
--- a/dist/react.force.net.js
+++ b/dist/react.force.net.js
@@ -161,7 +161,9 @@ const retrieve = (objtype, id, x, y, z) => {
         successCB = y;
         errorCB = z;
     }
-    const fields = fieldlist ? { fields: fieldlist } : null;
+    const fields = fieldlist
+        ? { fields: Array.isArray(fieldlist) ? fieldlist.join(",") : fieldlist }
+        : null;
     return (0, exports.sendRequest)("/services/data", `/${apiVersion}/sobjects/${objtype}/${id}`, successCB, errorCB, "GET", fields);
 };
 exports.retrieve = retrieve;

--- a/src/react.force.net.ts
+++ b/src/react.force.net.ts
@@ -221,7 +221,13 @@ export const retrieve: RetrieveOverload = <T>(
     errorCB = z as ExecErrorCallback;
   }
 
-  const fields = fieldlist ? { fields: fieldlist } : null;
+  // `fields` must cross the bridge as a comma-separated string. A raw string[]
+  // (the documented/typed form) would be URL-encoded as its Array toString
+  // (e.g. "[Name, Industry]") and rejected by Salesforce, so join it here. A
+  // string is passed through unchanged for the legacy pre-joined caller.
+  const fields = fieldlist
+    ? { fields: Array.isArray(fieldlist) ? fieldlist.join(",") : fieldlist }
+    : null;
   return sendRequest("/services/data", `/${apiVersion}/sobjects/${objtype}/${id}`, successCB, errorCB, "GET", fields);
 };
 


### PR DESCRIPTION
## Problem

`net.retrieve`'s public, typed, and documented signature takes `fieldlist: string[]`:

```ts
retrieve('Contact', id, ['FirstName', 'LastName'], onSuccess, onError)
```

…but the array was passed straight through to the native bridge as the `fields` query param:

```ts
const fields = fieldlist ? { fields: fieldlist } : null;
```

On Android the array is URL-encoded as its Java `ArrayList.toString()` → `fields=%5BFirstName%2C+LastName%5D` (i.e. `fields=[FirstName, LastName]`), which Salesforce rejects with `INVALID_FIELD` / 400; iOS can't produce a valid comma-joined value from an `NSArray` either. So **the documented/typed usage deterministically fails**, and the only form that works — a pre-joined string — contradicts the TypeScript signature. The shared `net.test.js` only ever passes a pre-joined string, so the typed path was never exercised.

## Fix

Join the array before it crosses the bridge; a string is passed through unchanged for the legacy pre-joined caller:

```ts
const fields = fieldlist
  ? { fields: Array.isArray(fieldlist) ? fieldlist.join(",") : fieldlist }
  : null;
```

## Note on `dist/` and the build

`main` points at `dist/index.js`, so the fix must ship in `dist/` too. However, `npm run build` (`tsc --build`) extends `@react-native/typescript-config`, which sets `noEmit: true` — so it **type-checks only and does not regenerate `dist/`**. The committed `dist/` is CommonJS produced by a separate release-time config; a naive `tsc` would re-emit the tree as ESM and break the package. So `dist/react.force.net.js` is **hand-synced** here to mirror the compiled `src` change (the `.d.ts` is unchanged — the signature is the same). Flagging the `noEmit` build discrepancy for a maintainer to look at separately; a maintainer may prefer to regenerate `dist/` with the real release tooling.

## Test plan

- [ ] Add a shared-suite assertion that calls `net.retrieve` with a `string[]` fieldlist (currently only the pre-joined-string form is tested).
- [ ] Verify a retrieve with `['FirstName','LastName']` returns the fields on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CGbVaRKrx7DeurX81NWdQ