### PR TITLE
fix(ios-tests): reduce testCleanResyncGhosts flakiness

### DIFF
--- a/test/mobilesync.test.js
+++ b/test/mobilesync.test.js
@@ -231,15 +231,14 @@ function testCleanResyncGhosts() {
     // Delete record from server (cleanup)
 
     registerSoup(storeConfig, soupName, indexSpecs)
-        .then((result) => {
-            return netCreate('contact', {FirstName: firstName, LastName: 'Last' + uniq});
-        })
-        .then((result) => {
-            contactId = result.id;
-            return netCreate('contact', {FirstName: otherFirstName, LastName: 'Last' + uniq});
-        })
-        .then((result) => {
-            otherContactId = result.id;
+        // Parallel creates: the two records are independent, so no need to serialize
+        .then(() => Promise.all([
+            netCreate('contact', {FirstName: firstName, LastName: 'Last' + uniq}),
+            netCreate('contact', {FirstName: otherFirstName, LastName: 'Last' + uniq}),
+        ]))
+        .then(([r1, r2]) => {
+            contactId = r1.id;
+            otherContactId = r2.id;
             return syncDown(storeConfig,
                             {'type':'soql', 'query':"SELECT Id, FirstName, LastName FROM Contact WHERE Id IN ('" + contactId + "', '" + otherContactId + "')"},
                             soupName,
@@ -248,7 +247,7 @@ function testCleanResyncGhosts() {
         })
         .then((result) => {
             syncId = result._soupEntryId;
-            assert.equal(result.totalSize, 2, 'Total size should be 1');
+            assert.equal(result.totalSize, 2, 'Total size should be 2');
             assert.equal(result.status, 'DONE', 'Status should be done');
             // order by needed: without it row order follows the SQLite plan (Id-index
             // order), and Salesforce Ids are not assigned in creation order.
@@ -257,24 +256,18 @@ function testCleanResyncGhosts() {
         })
         .then((result) => {
             assert.deepEqual(result.currentPageOrderedEntries, [[firstName],[otherFirstName]]);
-
             return netDel('contact', otherContactId);
         })
-        .then((result) => {
-            return cleanResyncGhosts(storeConfig, syncId);
-        })
-        .then(() => {
-            return runSmartQuery(storeConfig, querySpec);
-        })
+        // Brief pause so the deletion propagates before cleanResyncGhosts queries the server
+        .then(() => timeoutPromiser(1000))
+        .then(() => cleanResyncGhosts(storeConfig, syncId))
+        .then(() => runSmartQuery(storeConfig, querySpec))
         .then((result) => {
             assert.deepEqual(result.currentPageOrderedEntries, [[firstName]]);
-
-            // Cleanup
             return netDel('contact', contactId);
         })
-        .then((result) => { 
-            testDone();
-        });
+        .then(() => { testDone(); })
+        .catch((err) => { testDone(err); });
 };
 
 function testGetSyncStatusDeleteSync() {


### PR DESCRIPTION
## Summary

- **Parallelize independent `netCreate` calls** — the two contacts are independent; running them with `Promise.all` saves one full server RTT off the critical path
- **Add 1s pause after `netDel` before `cleanResyncGhosts`** — Salesforce has eventual consistency; the deletion needs a moment to propagate before the ghost-detection query runs (mirrors the existing pattern in `testReSync`)
- **Add `.catch()` handler** — without it, any transient network error causes the test to hang silently for the full 120s XCUITest timeout instead of failing immediately with a useful message
- **Fix wrong assertion message** — `'Total size should be 1'` → `'Total size should be 2'`

## Context

`testCleanResyncGhosts` has been the sole flapping test in the iOS suite for a while. It timed out in CI on both the `^18` and `^26` legs of PR #477. The test makes 6+ sequential network calls to a live Salesforce org; on a slow CI runner that easily lands on or past the 120s XCUITest timeout. The parallel creates address the root timing cause; the `.catch()` ensures that if it does time out in future, the failure is reported immediately with a message rather than as an opaque hang.

## Test plan

- [ ] Run `iosTests` locally: `xcodebuild test -workspace SalesforceReactTestApp.xcworkspace -scheme SalesforceReactTestApp -destination 'platform=iOS Simulator,name=iPhone 16 Pro'`
- [ ] Confirm `testCleanResyncGhosts` passes and completes faster than before
- [ ] Confirm all other MobileSync tests still pass