### PR TITLE
fix(android): guard against null ReadableArray in ReactBridgeHelper.toJavaList (W-23492982)

### DIFF
--- a/android/src/main/java/com/salesforce/androidsdk/reactnative/bridge/ReactBridgeHelper.java
+++ b/android/src/main/java/com/salesforce/androidsdk/reactnative/bridge/ReactBridgeHelper.java
@@ -156,6 +156,7 @@ public class ReactBridgeHelper  {
 
     public static List<Object> toJavaList(ReadableArray array) {
         List<Object> result = new ArrayList<>();
+        if (array == null) return result;
         for (int i = 0; i<array.size(); i++) {
             switch (array.getType(i)) {
                 case Null:

--- a/android/src/main/java/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.kt
+++ b/android/src/main/java/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.kt
@@ -170,6 +170,10 @@ class SmartStoreReactBridge(reactContext: ReactApplicationContext) :
         }
         val entriesList = ReactBridgeHelper.toJavaList(args.getArray(ENTRIES))
         val externalIdPath = args.getString(EXTERNAL_ID_PATH)
+        if (entriesList.isEmpty()) {
+            ReactBridgeHelper.invokeSuccess(callback, JSONArray().toString())
+            return
+        }
         val entries = entriesList.map { JSONObject(it as Map<*, *>) }
 
         // Run upsert


### PR DESCRIPTION
## Summary

- Add null guard in `ReactBridgeHelper.toJavaList` — returns empty list instead of NPE when a null `ReadableArray` is passed from the JS bridge
- Add early-return in `SmartStoreReactBridge.upsertSoupEntries` when the entries list is empty, returning an empty JSON array to the callback

## Root Cause

`toJavaList` called `array.size()` with no null check. When JavaScript passed `null` (or omitted) the `entries` argument to `upsertSoupEntries`, `args.getArray(ENTRIES)` returned null and the NPE followed immediately.

## GUS

W-23492982

## Reported via

https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues/2889