### PR TITLE
[ReactNative][Android] react-native-force calls removed ClientManager.peekUnauthenticatedRestClient()

### DIFF
--- a/android/src/main/java/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.kt
+++ b/android/src/main/java/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.kt
@@ -33,6 +33,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.turbomodule.core.interfaces.TurboModule
+import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.reactnative.ui.SalesforceReactActivity
 import com.salesforce.androidsdk.reactnative.util.SalesforceReactLogger
 import com.salesforce.androidsdk.rest.RestClient
@@ -228,7 +229,7 @@ open class SalesforceNetReactBridge(
     protected open fun getRestClient(doesNotRequireAuth: Boolean): RestClient? {
         val currentActivity = getCurrentActivity() as? SalesforceReactActivity ?: return null
         return if (doesNotRequireAuth) {
-            currentActivity.buildClientManager().peekUnauthenticatedRestClient()
+            SalesforceSDKManager.getInstance().getUnauthenticatedRestClient()
         } else {
             currentActivity.restClient
         }

--- a/android/src/main/java/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
+++ b/android/src/main/java/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
@@ -34,12 +34,14 @@ import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Callback;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.app.SalesforceSDKManager.RestClientCallback;
+import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.reactnative.R;
 import com.salesforce.androidsdk.reactnative.app.SalesforceReactSDKManager;
 import com.salesforce.androidsdk.reactnative.bridge.ReactBridgeHelper;
 import com.salesforce.androidsdk.reactnative.util.SalesforceReactLogger;
 import com.salesforce.androidsdk.rest.ClientManager;
-import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback;
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.ui.SalesforceActivityDelegate;
 import com.salesforce.androidsdk.ui.SalesforceActivityInterface;
@@ -173,7 +175,7 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
 
     protected void login() {
         SalesforceReactLogger.i(TAG, "login called");
-        clientManager.getRestClient(this, new RestClientCallback() {
+        SalesforceSDKManager.getInstance().getRestClient(this, new RestClientCallback() {
 
             @Override
             public void authenticatedRestClient(RestClient client) {
@@ -195,7 +197,7 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
      */
     public void logout(final Callback callback) {
         SalesforceReactLogger.i(TAG, "logout called");
-        SalesforceReactSDKManager.getInstance().logout(this);
+        SalesforceSDKManager.getInstance().logout(null, this, true, OAuth2.LogoutReason.UNKNOWN);
         if (callback != null) {
             ReactBridgeHelper.invokeSuccess(callback, "Logout complete");
         }
@@ -210,7 +212,7 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
         SalesforceReactLogger.i(TAG, "authenticate called");
         pendingAuthCallback = callback;
 
-        clientManager.getRestClient(this, new RestClientCallback() {
+        SalesforceSDKManager.getInstance().getRestClient(this, new RestClientCallback() {
 
             @Override
             public void authenticatedRestClient(RestClient client) {


### PR DESCRIPTION
## Summary

`SalesforceMobileSDK-Android`'s `ClientManager` rewrite for multi-user support (`716ee6625`) removed APIs that `react-native-force`'s Android bridge depended on, breaking the build for all four React Native Android templates.

- `SalesforceNetReactBridge.kt`: replaced removed `ClientManager.peekUnauthenticatedRestClient()` with `SalesforceSDKManager.getInstance().getUnauthenticatedRestClient()` (same pattern as the Cordova/Hybrid bridge).
- `SalesforceReactActivity.java`: replaced the removed `ClientManager.RestClientCallback` / async `getRestClient(activity, callback)` with the `SalesforceSDKManager` equivalents, and updated `logout()` to pass all four positional args (the new signature has no `@JvmOverloads`).

## Test plan

- [x] Local build via this repo's `androidTests/` subproject: `compileDebugKotlin`, `compileDebugJavaWithJavac`, and `:app:assembleDebug` all `BUILD SUCCESSFUL`.
- [x] End-to-end integration re-test against the pushed branch (template app + `yarn install` + Android build).

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*