### PR TITLE
[ReactNative][Android] Fix first launch without client manager

### DIFF
--- a/android/src/main/java/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
+++ b/android/src/main/java/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
@@ -103,10 +103,14 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
 
     @Override
     public void onResume(RestClient c) {
-        try {
-            setRestClient(clientManager.peekRestClient());
-        } catch (ClientManager.AccountInfoNotFoundException e) {
-            setRestClient(client);
+        clientManager = buildClientManager();
+        if (clientManager != null) {
+            final RestClient restClient = clientManager.peekRestClient();
+            if (restClient == null) {
+                logout(null);
+                return;
+            }
+            setRestClient(restClient);
         }
 
         // Not logged in.


### PR DESCRIPTION
## Summary
- rebuild the ClientManager when SalesforceReactActivity resumes
- preserve the normal unauthenticated login path when no manager exists on first launch
- log out and return when an existing manager cannot restore a RestClient
- remove handling for the legacy AccountInfoNotFoundException, since peekRestClient now reports failure with null

## Testing
- generated MobileSyncExplorerReactNative release app assembled successfully
- com.salesforce.mobilesdk.mobilesdkuitest.login.LoginTest passed on Pixel 10 API 36.1: 1 test, 0 failures