### PR TITLE
fix: defer iOS test credential initialization

### DIFF
--- a/iosTests/ios/SalesforceReactTestApp/AppDelegate.swift
+++ b/iosTests/ios/SalesforceReactTestApp/AppDelegate.swift
@@ -12,11 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
-
-  override init() {
-    super.init()
-    SalesforceReactSDKManager.initializeSDK()
-  }
+  private var startReactNative: (() -> Void)?
 
   func application(
     _ application: UIApplication,
@@ -33,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     window = UIWindow(frame: UIScreen.main.bounds)
 
-    AuthHelper.loginIfRequired() {
+    startReactNative = {
       factory.startReactNative(
         withModuleName: "SalesforceReactTestApp",
         in: self.window,
@@ -42,6 +38,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     return true
+  }
+
+  func applicationDidBecomeActive(_ application: UIApplication) {
+    guard let startReactNative else { return }
+    self.startReactNative = nil
+
+    // With -creds, SDK initialization performs a synchronous OAuth refresh.
+    // Run it only after UIKit has completed initial scene activation; re-entering
+    // the main run loop from the application initializer crashes iOS 18.
+    SalesforceReactSDKManager.initializeSDK()
+
+    // The SDK has already completed the UI-test login while consuming -creds.
+    if ProcessInfo.processInfo.arguments.contains("-creds") {
+      startReactNative()
+    } else {
+      AuthHelper.loginIfRequired() {
+        startReactNative()
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
## Summary
- defer SDK initialization until the application becomes active
- avoid re-entering the main run loop during initial scene activation when UI tests pass `-creds`
- retain normal authentication behavior outside UI-test launches

## Verification
- `ReactHarnessTests.testPassing()` passed on iOS 18.6 (iPhone 16 Pro simulator)
- `ReactHarnessTests.testPassing()` passed on iOS 26.5 (iPhone 17 Pro simulator)