### PR TITLE
W-24027227: Add iOS 27 to nightly CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,8 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ios: [^26, ^18]
+        ios: [^27, ^26, ^18]
         include:
+          - ios: ^27
+            xcode: ^27
+            macos: xcode-27
           - ios: ^26
             xcode: ^26
           - ios: ^18

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -53,7 +53,9 @@ jobs:
         env:
           XCODE_VERSION: ${{ inputs.xcode }}
         run: |
-          if [[ "$XCODE_VERSION" == "^26" ]]; then
+          if [[ "$XCODE_VERSION" == "^27" ]]; then
+            XCODE=$(ls -d /Applications/Xcode_27*.app 2>/dev/null | sort -V | tail -1)
+          elif [[ "$XCODE_VERSION" == "^26" ]]; then
             XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
           else
             XCODE=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)


### PR DESCRIPTION
## Summary
- add iOS 27 and Xcode 27 to the nightly React Native iOS test matrix
- teach the reusable workflow to select Xcode 27 before preparing and testing the app
- retain existing iOS 18 and iOS 26 coverage

## Validation
- parsed the edited workflows as YAML
- verified the iOS 27 matrix entry resolves to Xcode 27 on the xcode-27 runner
- ran git diff --check

Work item: [W-24027227](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002j5NcnYAE/view)