### PR TITLE
Fix xcodebuild log archive path in CI

### DIFF
--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -122,7 +122,7 @@ jobs:
         with:
           name: xcodebuild-logs-rn-ios${{ inputs.ios }}
           path: |
-            ~/Library/Developer/Xcode/DerivedData/**/Logs/Build/*.xcactivitylog
+            derived_data/Logs/Build/*.xcactivitylog
           if-no-files-found: ignore
           retention-days: 14
       - name: Verify xcresult bundle exists


### PR DESCRIPTION
## Summary
- The `upload-artifact` step was looking for xcodebuild logs at `~/Library/Developer/Xcode/DerivedData/**/Logs/Build/*.xcactivitylog` (the default Xcode location)
- But xcodebuild is called with `-derivedDataPath derived_data` (a relative path in the working directory), so logs are at `derived_data/Logs/Build/*.xcactivitylog`
- This meant the step always found no files and silently skipped uploading logs, making build failure diagnosis impossible

## Test plan
- [ ] Trigger a build failure and verify xcodebuild logs are uploaded as an artifact